### PR TITLE
Document mpInfoLegend members and GetPointed bugs.

### DIFF
--- a/mathplot/mathplot.cpp
+++ b/mathplot/mathplot.cpp
@@ -768,7 +768,7 @@ void mpInfoLegend::UpdateBitmap(wxDC &dc, mpWindow &w)
       posX += LEGEND_LINEWIDTH + MARGIN_LEGEND;
       buff_dc.DrawText(label, posX, posY - (tmpY >> 1));
 
-      posX += tmpX + MARGIN_LEGEND;
+      posX += tmpX + 2*MARGIN_LEGEND;
 
       if (m_item_direction == mpVertical)
       {
@@ -777,7 +777,7 @@ void mpInfoLegend::UpdateBitmap(wxDC &dc, mpWindow &w)
         posX = MARGIN_LEGEND;
         posY += tmpY;
         height = posY;
-        posY += MARGIN_LEGEND;
+        posY += 2*MARGIN_LEGEND;
       }
       else
       {
@@ -808,7 +808,7 @@ void mpInfoLegend::UpdateBitmap(wxDC &dc, mpWindow &w)
     buff_dc.DrawRectangle(0, 0, width, height);
     SetInfoRectangle(w, width, height);
 
-    // Transfert to the legend bitmap
+    // Transfer to the legend bitmap
     m_info_bmp = new wxBitmap(width, height, dc);
     wxMemoryDC buff_dc2(&dc);
     buff_dc2.SelectObject(*m_info_bmp);
@@ -859,8 +859,11 @@ int mpInfoLegend::GetPointed(mpWindow &w, wxPoint eventPoint)
 
   int rect_click, c = -1;
 
-  // We can consider that each name of serie is in an rectangular area.
-  // So we just need to determine in whitch rectangular we have clicked
+  // The name of each series is in an rectangular area.
+  // Determine in which rectangular we have clicked
+  // ToDo: BUG Code incorrectly assumes all labels are same length.
+  // ToDo: BUG Code incorrectly assumes InfoLegend box is not clipped.
+  // ToDo: BUG Replace all this code with a vector of, for each layer/legend, the actual drawn box containing legend
   if (m_item_direction == mpVertical)
     rect_click = (eventPoint.y - m_dim.y) / (m_dim.height / m_layer_count);
   else

--- a/mathplot/mathplot.h
+++ b/mathplot/mathplot.h
@@ -1005,8 +1005,8 @@ class WXDLLIMPEXP_MATHPLOT mpInfoLegend: public mpInfoLayer
       ;
     }
 
-    /** Swith item mode, which is the element on the left of text representing the plot line.
-     * @param mode The item draw mode: mpLEGEND_LINE or mpLEGEND_SQUARE. */
+    /** Set item mode (the element on the left of text representing the plot line may be line or square).
+     * @param mode Item draw mode: mpLEGEND_LINE or mpLEGEND_SQUARE. */
     void SetItemMode(mpLegendStyle mode)
     {
       m_item_mode = mode;
@@ -1034,6 +1034,7 @@ class WXDLLIMPEXP_MATHPLOT mpInfoLegend: public mpInfoLayer
       m_need_update = true;
     }
 
+    /// Return the index of visible layer whose legend is pointed at...
     int GetPointed(mpWindow &w, wxPoint eventPoint);
 
   protected:
@@ -1048,7 +1049,7 @@ class WXDLLIMPEXP_MATHPLOT mpInfoLegend: public mpInfoLayer
 
   private:
     bool m_need_update;
-    int m_layer_count;
+    int m_layer_count; //!< number of layers legend describes
     void UpdateBitmap(wxDC &dc, mpWindow &w);
 
   DECLARE_DYNAMIC_CLASS(mpInfoLegend)
@@ -3026,7 +3027,7 @@ class WXDLLIMPEXP_MATHPLOT mpWindow: public wxWindow
     mpOnUserMouseAction m_OnUserMouseAction = NULL;  //!< Event when we have a mouse click
 
     /// To be notified of displayed bounds changes (after user zoom etc),
-    /// override this callback in your derived class and look at new value of m_desired.
+    /// override this callback in your derived class and look at the new value of m_desired.
     /// Useful for keeping multiple plots in sync when user zooms.
     virtual void DesiredBoundsHaveChanged() {};
 


### PR DESCRIPTION
@GitHubLionel - Will you be able to fix this?
I've suggested a fix; just track bounding boxes for each plot legend in a vector or list,
then iterate over the vector and check "IsInside"...
Thanks! 