### PR TITLE
Use better axis label step size

### DIFF
--- a/mathplot/mathplot.h
+++ b/mathplot/mathplot.h
@@ -1995,7 +1995,14 @@ class WXDLLIMPEXP_MATHPLOT mpScale: public mpLayer
     wxString m_labelFormat;  //!< Format string used to print labels
 
     virtual int GetOrigin(mpWindow &w) = 0;
-    double GetStep(double scale);
+
+    /** Calculate a 'nice' label step size for the given dataset and desired pixel spacing. Label step
+     * size are considered nice if they are 1, 2, 5 or 10 raised to an appropriate power of 10.
+     @param The scale of the axis, denoted in [pixels / data value]
+     @param The minimum wanted label spacing in pixels
+     @return The 'nice' step size for the interval
+     */
+    double GetStep(double scale, int minLabelSpacing);
     virtual void DrawScaleName(wxDC &dc, mpWindow &w, int origin, int labelSize) = 0;
 
     wxString FormatLogValue(double n);
@@ -2074,6 +2081,13 @@ class WXDLLIMPEXP_MATHPLOT mpScaleX: public mpScale
     /** Layer plot handler.
      This implementation will plot the ruler adjusted to the visible area. */
     virtual void DoPlot(wxDC &dc, mpWindow &w);
+
+    /** Get label width given a value and a format string
+     @param Data value
+     @param Current dc
+     @param Format string that shall be used for this value
+     @return Label width */
+    wxCoord GetLabelWidth(double value, wxDC &dc, wxString fmt);
 
     virtual int GetOrigin(mpWindow &w);
     virtual void DrawScaleName(wxDC &dc, mpWindow &w, int origin, int labelSize);
@@ -2516,7 +2530,7 @@ class WXDLLIMPEXP_MATHPLOT mpWindow: public wxWindow
      * @sa p2y,x2p,y2p */
     inline double p2x(const wxCoord pixelCoordX) const
     {
-      return m_posX + pixelCoordX / m_scaleX;
+      return m_posX + (pixelCoordX / m_scaleX);
     }
 
     /** Converts mpWindow (screen) pixel coordinates into graph (floating point) coordinates,
@@ -2524,7 +2538,7 @@ class WXDLLIMPEXP_MATHPLOT mpWindow: public wxWindow
      * @sa p2x,x2p,y2p */
     inline double p2y(const wxCoord pixelCoordY, int yIndex = 0) const
     {
-      return m_yAxisDataList[yIndex].m_posY - pixelCoordY / m_yAxisDataList[yIndex].m_scaleY;
+      return m_yAxisDataList[yIndex].m_posY - (pixelCoordY / m_yAxisDataList[yIndex].m_scaleY);
     }
 
     /** Converts graph (floating point) coordinates into mpWindow (screen) pixel coordinates,


### PR DESCRIPTION
The distance between axis ticks and labels is considered nice if it is a multiple of 10 raised to appropriate power, i.e. 1, 2, 5 or 10. Previous implementation only used powers of 10, i.e. 0.1, 1, 10 etc, which made the number of ticks and steps jump a lot. Using 0.1, 0.2, 0.5, 1, 2, 5, 10, 20, etc insted produces a much smoother plot, especially when zooming in and out, and is very common in various plotting libraries.

Furthermore, the way the distances between the labels was handled made the labels jump back and forth just by paning due to how the labels were filtered away since labels was not shown on every tick. Better to add a label to every tick so that the labels doesn't change place as you pan around.

The new implementation also makes sure that we have at least 50 pixels center distance between each tick or 20 pixels separation between each label on the X-axis since they can get pretty wide. The 50 pixels is a bit more spaced than before, but my thought was that this looked ok, and is similar to how it looks in other plots like Matlab. Let me know if you prefer another spacing. It would also be an idea to add "in-between" grid lines without labels.

**Issue1: Large step change from 1 to 10:**
![Axis tick large step change](https://github.com/user-attachments/assets/ce867588-3625-42cc-af02-06998cb96da9)

**Issue2: Labels jumps around when panning:**
![Axis label jumps around](https://github.com/user-attachments/assets/2ec6039c-9930-44c4-a86c-f35cbab97259)

**After fix:**
![Axis tick fix](https://github.com/user-attachments/assets/e87502b0-ab35-4edd-863c-ce000595a4b4)

