### PR TITLE
Auto update Y-axis width

### DIFF
--- a/mathplot/mathplot.h
+++ b/mathplot/mathplot.h
@@ -2087,7 +2087,7 @@ class WXDLLIMPEXP_MATHPLOT mpScaleX: public mpScale
      @param Current dc
      @param Format string that shall be used for this value
      @return Label width */
-    wxCoord GetLabelWidth(double value, wxDC &dc, wxString fmt);
+    int GetLabelWidth(double value, wxDC &dc, wxString fmt);
 
     virtual int GetOrigin(mpWindow &w);
     virtual void DrawScaleName(wxDC &dc, mpWindow &w, int origin, int labelSize);
@@ -2123,6 +2123,10 @@ class WXDLLIMPEXP_MATHPLOT mpScaleY: public mpScale
     virtual bool IsLogAxis();
     virtual void SetLogAxis(bool log);
 
+    /** Recalculated the axis width based on the label and name text sizes
+    @param Current windows used as canvas */
+    void UpdateAxisWidth(mpWindow &w);
+
     size_t GetAxisIndex(void)
     {
       return m_axisIndex;
@@ -2142,6 +2146,8 @@ class WXDLLIMPEXP_MATHPLOT mpScaleY: public mpScale
     virtual void DoPlot(wxDC &dc, mpWindow &w);
 
     virtual int GetOrigin(mpWindow &w);
+    wxString GetLabelFormat(mpWindow &w);
+    int GetLabelWidth(double value, wxDC &dc, wxString fmt);
     virtual void DrawScaleName(wxDC &dc, mpWindow &w, int origin, int labelSize);
 
   wxDECLARE_DYNAMIC_CLASS(mpScaleY);


### PR DESCRIPTION
Depending on label and name size, the Y-axis width can differ and need to by updated dynamically as you zoom or change font on the axis.To calculate width, the label and label format need to be known, which currently only is calculated in OnPaint->DoPlot, but we don't want to update axis width in a OnPaint event. Instead move the calculation of label format to a function and us it in UpdateAll() to make sure that axis width is up to date before the OnPaint event is triggered,

Now that we automatically adjust the axis width, there's no reason to draw the axis name horizontally, thus always point it vertically. At least for mpALIGN_LEFT and mpALIGN_RIGHT.

Also a minor change regarding the extra margin since the first Y-axis ends up outside of the plot otherwise

Will solve [Issue 90](https://github.com/GitHubLionel/wxMathPlot/issues/90)

**Zooming**
![Axis width zoom](https://github.com/user-attachments/assets/710b84e1-3f99-4067-8d30-14d18e9bf09e)

**Enlarge font**
![Axis width large font 2](https://github.com/user-attachments/assets/41b174f4-228e-42e1-8b0f-0e2a26495589)
