### PR TITLE
Zooming and paning on individual Y-axis

### DIFF
--- a/mathplot/mathplot.cpp
+++ b/mathplot/mathplot.cpp
@@ -2445,6 +2445,7 @@ int mpScaleY::GetOrigin(mpWindow &w)
     case mpALIGN_BORDER_LEFT:
     {
       origin = w.GetLeftYAxesWidth(GetAxisIndex()) + 1;
+      m_xPos = origin;
       break;
     }
     case mpALIGN_LEFT:
@@ -2452,23 +2453,27 @@ int mpScaleY::GetOrigin(mpWindow &w)
       origin = w.GetLeftYAxesWidth(GetAxisIndex()) + GetAxisWidth() - EXTRA_MARGIN - 1;
       if (!m_drawOutsideMargins)
         origin += w.GetMarginLeftOuter();
+      m_xPos = origin - GetAxisWidth();
       break;
     }
     case mpALIGN_CENTERY:
       origin = w.x2p(0);
       if (!m_drawOutsideMargins && ((origin > (w.GetScreenX() - w.GetMarginRight())) || (origin + 1 < w.GetMarginLeft())))
         origin = -1;
+      m_xPos = origin;
       break;
     case mpALIGN_RIGHT:
     {
       origin = w.GetScreenX() - w.GetRightYAxesWidth(GetAxisIndex()) - GetAxisWidth() + EXTRA_MARGIN - 2;
       if (!m_drawOutsideMargins)
         origin -= w.GetMarginRightOuter();
+      m_xPos = origin;
       break;
     }
     case mpALIGN_BORDER_RIGHT:
     {
       origin = w.GetScreenX() - w.GetRightYAxesWidth(GetAxisIndex()) - 1;
+      m_xPos = origin - GetAxisWidth();
       break;
     }
 
@@ -2788,6 +2793,7 @@ void mpWindow::InitParameters()
   m_enableDoubleBuffer = true;
   m_enableMouseNavigation = true;
   m_mouseMovedAfterRightClick = false;
+  m_mouseYAxisIndex = std::nullopt;
   m_movingInfoLayer = NULL;
   m_InfoCoords = NULL;
   m_InfoLegend = NULL;
@@ -2874,6 +2880,7 @@ void mpWindow::OnMouseRightDown(wxMouseEvent &event)
 
   m_mouseMovedAfterRightClick = false;
   m_mouseRClick = wxPoint(event.GetX(), event.GetY());
+  m_mouseYAxisIndex = IsInsideYAxis(m_mouseRClick);
   if (m_magnetize)
     m_magnet.SetRightClick();
 
@@ -2908,18 +2915,34 @@ void mpWindow::OnMouseMove(wxMouseEvent &event)
     // For the next event, use relative to this coordinates.
     m_mouseRClick = eventPoint;
 
-    double Ax_units = Axy.x / m_scaleX;
-    m_posX += Ax_units;
-    m_desired.Xmax += Ax_units;
-    m_desired.Xmin += Ax_units;
-
-    for(size_t i = 0; i < m_yAxisDataList.size(); i++)
+    if(m_mouseYAxisIndex)
     {
-      double Ay_units = -Axy.y / m_yAxisDataList[i].m_scaleY;
-      m_yAxisDataList[i].m_posY += Ay_units;
-      m_desired.YminList[i] += Ay_units;
-      m_desired.YmaxList[i] += Ay_units;
+      // A specific Y-axis has been selected. Only pan on that
+      double Ay_units = -Axy.y / m_yAxisDataList[*m_mouseYAxisIndex].m_scaleY;
+      m_yAxisDataList[*m_mouseYAxisIndex].m_posY += Ay_units;
+      m_desired.YminList[*m_mouseYAxisIndex] += Ay_units;
+      m_desired.YmaxList[*m_mouseYAxisIndex] += Ay_units;
     }
+    else
+    {
+      // No axis selected. Pan whole plot
+      double Ax_units = Axy.x / m_scaleX;
+      m_posX += Ax_units;
+      m_desired.Xmax += Ax_units;
+      m_desired.Xmin += Ax_units;
+
+      for(size_t i = 0; i < m_yAxisDataList.size(); i++)
+      {
+        double Ay_units = -Axy.y / m_yAxisDataList[i].m_scaleY;
+        m_yAxisDataList[i].m_posY += Ay_units;
+        m_desired.YminList[i] += Ay_units;
+        m_desired.YmaxList[i] += Ay_units;
+      }
+    }
+
+
+
+
 
     UpdateAll();
     CheckAndReportDesiredBoundsChanges();
@@ -3057,8 +3080,20 @@ void mpWindow::OnMouseWheel(wxMouseEvent &event)
   // Zoom in and out
   if (!event.m_controlDown && !event.m_shiftDown)
   {
-    // CTRL key hold: Zoom in/out:
-    Zoom((event.GetWheelRotation() > 0), wxPoint(event.GetX(), event.GetY()));
+    // No key hold: Zoom in/out:
+    wxPoint eventPoint = wxPoint(event.GetX(), event.GetY());
+    std::optional<size_t> yAxisIndex = IsInsideYAxis(eventPoint);
+    if(yAxisIndex)
+    {
+      // Only zoom selected Y-axis around mouse position
+      DoZoomYCalc((event.GetWheelRotation() > 0), eventPoint.y, *yAxisIndex);
+      UpdateAll();
+    }
+    else
+    {
+      // Zoom whole plot around mouse position
+      Zoom((event.GetWheelRotation() > 0), eventPoint);
+    }
   }
   else
   {
@@ -3072,17 +3107,16 @@ void mpWindow::OnMouseWheel(wxMouseEvent &event)
       m_desired.Xmax += changeUnitsX;
       m_desired.Xmin += changeUnitsX;
     }
-    else
-      if (event.m_controlDown)
+    else if (event.m_controlDown)
+    {
+      for(size_t i = 0; i < m_yAxisDataList.size(); i++)
       {
-        for(size_t i = 0; i < m_yAxisDataList.size(); i++)
-        {
-          double changeUnitsY = change / m_yAxisDataList[i].m_scaleY;
-          m_yAxisDataList[i].m_posY -= changeUnitsY;
-          m_desired.YminList[i] -= changeUnitsY;
-          m_desired.YmaxList[i] -= changeUnitsY;
-        }
+        double changeUnitsY = change / m_yAxisDataList[i].m_scaleY;
+        m_yAxisDataList[i].m_posY -= changeUnitsY;
+        m_desired.YminList[i] -= changeUnitsY;
+        m_desired.YmaxList[i] -= changeUnitsY;
       }
+    }
 
     UpdateAll();
     CheckAndReportDesiredBoundsChanges();
@@ -3218,78 +3252,61 @@ void mpWindow::CheckAndReportDesiredBoundsChanges() {
 }
 
 // Patch ngpaton
-void mpWindow::DoZoomInXCalc(const int staticXpixel)
+void mpWindow::DoZoomXCalc(bool zoomIn, int staticXpixel)
 {
+  if(staticXpixel == ZOOM_AROUND_CENTER)
+  {
+    // Zoom around center
+    staticXpixel = (m_plotWidth / 2) + m_margin.left;
+  }
+
   // Preserve the position of the clicked point:
   double staticX = p2x(staticXpixel);
-  // Zoom in:
-  m_scaleX *= m_zoomIncrementalFactor;
+  // Zoom:
+  double zoomFactor = zoomIn ? m_zoomIncrementalFactor : (1.0 / m_zoomIncrementalFactor);
+  m_scaleX *= zoomFactor;
+
   // Adjust the new m_posx
   m_posX = staticX - (staticXpixel / m_scaleX);
+
   // Adjust desired
   m_desired.Xmin = m_posX;
   m_desired.Xmax = m_posX + m_plotWidth / m_scaleX;
   CheckAndReportDesiredBoundsChanges();
 #ifdef MATHPLOT_DO_LOGGING
-  wxLogMessage(_T("mpWindow::DoZoomInXCalc() prior X coord: (%f), new X coord: (%f) SHOULD BE EQUAL!!"), staticX, p2x(staticXpixel));
+  wxLogMessage(_T("mpWindow::DoZoomXCalc() prior X coord: (%f), new X coord: (%f) SHOULD BE EQUAL!!"), staticX, p2x(staticXpixel));
 #endif
 }
 
-void mpWindow::DoZoomInYCalc(const int staticYpixel)
+void mpWindow::DoZoomYCalc(bool zoomIn, int staticYpixel, std::optional<size_t> yIndex)
 {
-  for(size_t i = 0; i < m_yAxisDataList.size(); i++)
+  if(staticYpixel == ZOOM_AROUND_CENTER)
+  {
+    // Zoom around center
+    staticYpixel = (m_plotHeight / 2) + m_margin.top;
+  }
+
+  // If yIndex is supplied, only zoom in on that specific Y-axis
+  size_t startIndex = yIndex ? (*yIndex)     : 0;
+  size_t endIndex   = yIndex ? (*yIndex + 1) : m_yAxisDataList.size();
+
+  double zoomFactor = zoomIn ? m_zoomIncrementalFactor : (1.0 / m_zoomIncrementalFactor);
+  for(size_t i = startIndex; i < endIndex; i++)
   {
     // Preserve the position of the clicked point:
     double staticY = p2y(staticYpixel, i);
-    // Zoom in:
-    m_yAxisDataList[i].m_scaleY *= m_zoomIncrementalFactor;
+    // Zoom:
+    m_yAxisDataList[i].m_scaleY *= zoomFactor;
     // Adjust the new m_posy:
     m_yAxisDataList[i].m_posY = staticY + (staticYpixel / m_yAxisDataList[i].m_scaleY);
     // Adjust desired
     m_desired.YmaxList[i] = m_yAxisDataList[i].m_posY;
     m_desired.YminList[i] = m_yAxisDataList[i].m_posY - m_plotHeight / m_yAxisDataList[i].m_scaleY;
   }
-  CheckAndReportDesiredBoundsChanges();
-#ifdef MATHPLOT_DO_LOGGING
-  wxLogMessage(_T("mpWindow::DoZoomInYCalc() prior Y coord: (%f), new Y coord: (%f) SHOULD BE EQUAL!!"), staticY, p2y(staticYpixel));
-#endif
-}
-
-void mpWindow::DoZoomOutXCalc(const int staticXpixel)
-{
-  // Preserve the position of the clicked point:
-  double staticX = p2x(staticXpixel);
-  // Zoom out:
-  m_scaleX /= m_zoomIncrementalFactor;
-  // Adjust the new m_posx/y:
-  m_posX = staticX - (staticXpixel / m_scaleX);
-  // Adjust desired
-  m_desired.Xmin = m_posX;
-  m_desired.Xmax = m_posX + m_plotWidth / m_scaleX;
-  CheckAndReportDesiredBoundsChanges();
-#ifdef MATHPLOT_DO_LOGGING
-  wxLogMessage(_T("mpWindow::DoZoomOutXCalc() prior X coord: (%f), new X coord: (%f) SHOULD BE EQUAL!!"), staticX, p2x(staticXpixel));
-#endif
-}
-
-void mpWindow::DoZoomOutYCalc(const int staticYpixel)
-{
-  for(size_t i = 0; i < m_yAxisDataList.size(); i++)
-  {
-    // Preserve the position of the clicked point:
-    double staticY = p2y(staticYpixel, i);
-    // Zoom out:
-    m_yAxisDataList[i].m_scaleY /= m_zoomIncrementalFactor;
-    // Adjust the new m_posx/y:
-    m_yAxisDataList[i].m_posY = staticY + (staticYpixel / m_yAxisDataList[i].m_scaleY);
-    // Adjust desired
-    m_desired.YmaxList[i] = m_yAxisDataList[i].m_posY;
-    m_desired.YminList[i] = m_yAxisDataList[i].m_posY - m_plotHeight / m_yAxisDataList[i].m_scaleY;
-  }
 
   CheckAndReportDesiredBoundsChanges();
 #ifdef MATHPLOT_DO_LOGGING
-  wxLogMessage(_T("mpWindow::DoZoomOutYCalc() prior Y coord: (%f), new Y coord: (%f) SHOULD BE EQUAL!!"), staticY, p2y(staticYpixel));
+  wxLogMessage(_T("mpWindow::DoZoomYCalc() prior Y coord: (%f), new Y coord: (%f) SHOULD BE EQUAL!!"), staticY, p2y(staticYpixel));
 #endif
 }
 
@@ -3305,36 +3322,17 @@ void mpWindow::ZoomOut(const wxPoint &centerPoint)
 
 void mpWindow::Zoom(bool zoomIn, const wxPoint &centerPoint)
 {
-  wxPoint c(centerPoint);
-  if (c == wxDefaultPosition)
+  if (centerPoint == wxDefaultPosition)
   {
-    int h, w;
-    GetClientSize(&w, &h);
-    SetScreen(w, h);
-    c.x = m_plotWidth / 2 + m_margin.left;
-    c.y = m_plotHeight / 2 - m_margin.top;
+    // Zoom around plot center
+    DoZoomXCalc(zoomIn);
+    DoZoomYCalc(zoomIn);
   }
-
-  // Preserve the position of the clicked point:
-  double prior_layer_x = p2x(c.x);
-
-  double zoomFactor = zoomIn?m_zoomIncrementalFactor : 1.0/m_zoomIncrementalFactor;
-  m_scaleX *= zoomFactor;
-
-  // Adjust the new m_posx:
-  m_posX = prior_layer_x - c.x / m_scaleX;
-
-  m_desired.Xmin = m_posX;
-  m_desired.Xmax = m_posX + m_plotWidth / m_scaleX;
-
-  // Same for Y
-  for(size_t i = 0; i < m_yAxisDataList.size(); i++)
+  else
   {
-    double prior_layer_y = p2y(c.y, i);
-    m_yAxisDataList[i].m_scaleY *= zoomFactor;
-    m_yAxisDataList[i].m_posY = prior_layer_y + c.y / m_yAxisDataList[i].m_scaleY;
-    m_desired.YmaxList[i] = m_yAxisDataList[i].m_posY;
-    m_desired.YminList[i] = m_yAxisDataList[i].m_posY - m_plotHeight / m_yAxisDataList[i].m_scaleY;
+    // Zoom around this point
+    DoZoomXCalc(zoomIn, centerPoint.x);
+    DoZoomYCalc(zoomIn, centerPoint.y);
   }
 
 #ifdef MATHPLOT_DO_LOGGING
@@ -3342,59 +3340,30 @@ void mpWindow::Zoom(bool zoomIn, const wxPoint &centerPoint)
       prior_layer_x, prior_layer_y, p2x(c.x), p2y(c.y));
 #endif
   UpdateAll();
-  CheckAndReportDesiredBoundsChanges();
 }
 
 void mpWindow::ZoomInX()
 {
-  m_scaleX *= m_zoomIncrementalFactor;
+  DoZoomXCalc(true);
   UpdateAll();
-  CheckAndReportDesiredBoundsChanges();
 }
 
 void mpWindow::ZoomOutX()
 {
-  m_scaleX /= m_zoomIncrementalFactor;
+  DoZoomXCalc(false);
   UpdateAll();
-  CheckAndReportDesiredBoundsChanges();
 }
 
-void mpWindow::ZoomInY()
+void mpWindow::ZoomInY(std::optional<size_t> yIndex)
 {
-  for(size_t i = 0; i < m_yAxisDataList.size(); i++)
-  {
-    m_yAxisDataList[i].m_scaleY *= m_zoomIncrementalFactor;
-  }
-
+  DoZoomYCalc(true, ZOOM_AROUND_CENTER, yIndex);
   UpdateAll();
-  CheckAndReportDesiredBoundsChanges();
 }
 
-void mpWindow::ZoomOutY()
+void mpWindow::ZoomOutY(std::optional<size_t> yIndex)
 {
-  for(size_t i = 0; i < m_yAxisDataList.size(); i++)
-  {
-    m_yAxisDataList[i].m_scaleY /= m_zoomIncrementalFactor;
-  }
-
+  DoZoomYCalc(false, ZOOM_AROUND_CENTER, yIndex);
   UpdateAll();
-  CheckAndReportDesiredBoundsChanges();
-}
-
-void mpWindow::ZoomInYByIndex(int yIndex)
-{
-  m_yAxisDataList[yIndex].m_scaleY *= m_zoomIncrementalFactor;
-
-  UpdateAll();
-  CheckAndReportDesiredBoundsChanges();
-}
-
-void mpWindow::ZoomOutYByIndex(int yIndex)
-{
-  m_yAxisDataList[yIndex].m_scaleY /= m_zoomIncrementalFactor;
-
-  UpdateAll();
-  CheckAndReportDesiredBoundsChanges();
 }
 
 void mpWindow::ZoomRect(wxPoint p0, wxPoint p1)
@@ -4425,6 +4394,18 @@ mpScaleX* mpWindow::GetLayerXAxis()
   return NULL;    // Not found
 }
 
+std::optional<size_t> mpWindow::IsInsideYAxis(const wxPoint &point)
+{
+  for(mpScaleY* yAxis : m_YAxisList)
+  {
+    if(yAxis->IsInside(point.x))
+    {
+      return yAxis->GetAxisIndex();
+    }
+  }
+  return std::nullopt;
+}
+
 mpInfoLayer* mpWindow::IsInsideInfoLayer(const wxPoint &point)
 {
   for (mpLayerList::iterator it = m_layers.begin(); it != m_layers.end(); it++)
@@ -4519,7 +4500,7 @@ int mpWindow::GetLeftYAxesWidth(int yAxisIndex)
   int yAxesWidth = 0;
   for(mpScaleY* yAxis : GetYAxisList())
   {
-    if(((yAxis->GetAlign() == mpALIGN_BORDER_LEFT) || (yAxis->GetAlign() == mpALIGN_LEFT)) && ((yAxisIndex == -1) || (yAxis->GetAxisIndex() < (size_t)yAxisIndex)))
+    if(yAxis->IsLeftAxis() && ((yAxisIndex == -1) || (yAxis->GetAxisIndex() < (size_t)yAxisIndex)))
     {
       // For every left y-axis that is left of this one (lower index), add its width
       yAxesWidth += yAxis->GetAxisWidth();
@@ -4533,7 +4514,7 @@ int mpWindow::GetRightYAxesWidth(int yAxisIndex)
   int yAxesWidth = 0;
   for(mpScaleY* yAxis : GetYAxisList())
   {
-    if(((yAxis->GetAlign() == mpALIGN_BORDER_RIGHT) || (yAxis->GetAlign() == mpALIGN_RIGHT)) && ((yAxisIndex == -1) || (yAxis->GetAxisIndex() < (size_t)yAxisIndex)))
+    if(yAxis->IsRightAxis() && ((yAxisIndex == -1) || (yAxis->GetAxisIndex() < (size_t)yAxisIndex)))
     {
       // For every right y-axis that is right of this one (lower index), add its width
       yAxesWidth += yAxis->GetAxisWidth();

--- a/mathplot/mathplot.h
+++ b/mathplot/mathplot.h
@@ -68,6 +68,7 @@
 #endif
 
 #include <vector>
+#include <optional>
 
 // #include <wx/wx.h>
 #include <wx/defs.h>
@@ -128,6 +129,8 @@
 
 // A small extra margin for the plot boundary
 #define EXTRA_MARGIN  8
+
+#define ZOOM_AROUND_CENTER  -1
 
 //-----------------------------------------------------------------------------
 // classes
@@ -2115,6 +2118,7 @@ class WXDLLIMPEXP_MATHPLOT mpScaleY: public mpScale
       m_subtype = mpsScaleY;
       m_axisWidth = Y_BORDER_SEPARATION;
       m_axisIndex = axisIndex;
+      m_xPos = 0;
     }
 
     /**
@@ -2133,9 +2137,29 @@ class WXDLLIMPEXP_MATHPLOT mpScaleY: public mpScale
       return m_axisWidth;
     }
 
+    bool IsLeftAxis()
+    {
+      return ((GetAlign() == mpALIGN_BORDER_LEFT) || (GetAlign() == mpALIGN_LEFT));
+    }
+
+    bool IsRightAxis()
+    {
+      return ((GetAlign() == mpALIGN_BORDER_RIGHT) || (GetAlign() == mpALIGN_RIGHT));
+    }
+
+    bool IsInside(wxCoord xPixel)
+    {
+      if( (IsLeftAxis() || IsRightAxis()) && (xPixel >= m_xPos) && (xPixel <= (m_xPos + m_axisWidth)) )
+      {
+        return true;
+      }
+      return false;
+    }
+
   protected:
     int m_axisWidth;
     size_t m_axisIndex;
+    int m_xPos;
 
     /** Layer plot handler.
      This implementation will plot the ruler adjusted to the visible area. */
@@ -2622,23 +2646,19 @@ class WXDLLIMPEXP_MATHPLOT mpWindow: public wxWindow
      */
     void ZoomOut(const wxPoint &centerPoint = wxDefaultPosition);
 
-    /** Zoom in current view along X and refresh display */
+    /** Zoom in current view along X around center and refresh display */
     void ZoomInX();
 
-    /** Zoom out current view along X and refresh display */
+    /** Zoom out current view along X around center and refresh display */
     void ZoomOutX();
 
-    /** Zoom in current view along Y and refresh display */
-    void ZoomInY();
+    /** Zoom in current view along Y around center and refresh display
+    @param Optional Y-axis index used to specify which Y-axis to zoom */
+    void ZoomInY(std::optional<size_t> yIndex = std::nullopt);
 
-    /** Zoom out current view along Y and refresh display */
-    void ZoomOutY();
-
-    /** Zoom in current view along specified Y axis and refresh display */
-    void ZoomInYByIndex(int yIndex);
-
-    /** Zoom out current view along specified Y axis and refresh display */
-    void ZoomOutYByIndex(int yIndex);
+    /** Zoom out current view along Y around center and refresh display
+    @param Optional Y-axis index used to specify which Y-axis to zoom */
+    void ZoomOutY(std::optional<size_t> yIndex = std::nullopt);
 
     /** Zoom view fitting given coordinates to the window (p0 and p1 do not need to be in any specific order) */
     void ZoomRect(wxPoint p0, wxPoint p1);
@@ -2876,6 +2896,11 @@ class WXDLLIMPEXP_MATHPLOT mpWindow: public wxWindow
       return m_drawBox;
     }
 
+    /** Check if a given point is inside the area of a Y-axis and returns its index if so.
+     @param point The position to be checked
+     @return If the point is inside a Y-Axis, returns it index, otherwise -1 */
+    std::optional<size_t> IsInsideYAxis(const wxPoint &point);
+
     /** Check if a given point is inside the area of a mpInfoLayer and eventually returns its pointer.
      @param point The position to be checked
      @return If an info layer is found, returns its pointer, NULL otherwise */
@@ -3033,10 +3058,19 @@ class WXDLLIMPEXP_MATHPLOT mpWindow: public wxWindow
 
     void DoScrollCalc(const int position, const int orientation);
 
-    void DoZoomInXCalc(const int staticXpixel);
-    void DoZoomInYCalc(const int staticYpixel);
-    void DoZoomOutXCalc(const int staticXpixel);
-    void DoZoomOutYCalc(const int staticYpixel);
+    /** Zoom in or out X around a X position. Is the position is not set, it will zoom around center.
+     * @param Zoom in or zoom out boolean
+     * @param Optional center position
+     * */
+    void DoZoomXCalc(bool zoomIn, int staticXpixel = ZOOM_AROUND_CENTER);
+
+    /** Zoom in or out Y around a Y position. Is the position is not set, it will zoom around center.
+     * An optional Y-axis index can be passe to only zoom a specific Y-axis
+     * @param Zoom in or zoom out boolean
+     * @param Optional center position
+     * @param Optional Y-axis index used to specify which Y-axis to zoom
+     * */
+    void DoZoomYCalc(bool zoomIn, int staticYpixel = ZOOM_AROUND_CENTER, std::optional<size_t> = std::nullopt);
 
     void Zoom(bool zoomIn, const wxPoint &centerPoint);
 
@@ -3105,6 +3139,7 @@ class WXDLLIMPEXP_MATHPLOT mpWindow: public wxWindow
     bool m_mouseMovedAfterRightClick;
     wxPoint m_mouseRClick;              //!< For the right button "drag" feature
     wxPoint m_mouseLClick;              //!< Starting coords for rectangular zoom selection
+    std::optional<size_t> m_mouseYAxisIndex; //!< Indicate which Y-axis the mouse was on during zoom/pan
     bool m_enableScrollBars;
     int m_scrollX, m_scrollY;
     mpInfoLayer* m_movingInfoLayer;     //!< For moving info layers over the window area


### PR DESCRIPTION
If you only want to zoom or pan a specific Y-axis it can now be done by holding the mouse over a specific Y-axis while wheel-scrolling or paning. Thus we nee do keep track of all Y-axis areas, which can be achieved via its m_xPos and m_axisWidth. Not supported on centered Y-axis (only left and right aligned) since they don't have a dedicated area so to say. And you wouldn't want multiple centered Y-axis anyway.

Also restructured the functions DoZoomInXCalc(), DoZoomInYCalc(), DoZoomOutXCalc(), DoZoomOutYCalc() and Zoom() since they were very much alike, i.e. a lot of code duplication. Restructured to only have DoZoomXCalc(), DoZoomYCalc() and Zoom(), where Zoom() then calls both DoZoomXCalc() and DoZoomYCalc(). Also let ZoomInX(), ZoomOutX(), ZoomInY() and ZoomOutY() use these functions instead of just adjusting m_scaleX / m_scaleY which will zoom around left or upper border which I don't think is expected. You expect a function like ZoomInX() to zoom around center by default.

Introduced c++17 std::optional<> since its very convinient/safe for optional argument rather than relying on a magic number such as -1. Not sure if you are ok with c++17 features in this library? Otherwise I can resort to magic number approach or if you have another suggestion?

**Paning individual y-axis with right click**
![Pan y axis](https://github.com/user-attachments/assets/3d4893d9-7461-45db-86b0-f429fa989c32)

**Zooming individual y-axis with mouse scroll**
![Zoom y axis](https://github.com/user-attachments/assets/de9b0c5b-8005-441c-90dc-0a42de6a1e80)

