### PR TITLE
Add demo for multiply Y-axis

### DIFF
--- a/MathPlotDemo/MathPlotDemoMain.h
+++ b/MathPlotDemo/MathPlotDemoMain.h
@@ -47,6 +47,7 @@ class MathPlotDemoFrame: public wxFrame
         void OnbBarChartClick(wxCommandEvent& event);
         void OncbFreeLineClick(wxCommandEvent& event);
         void OnbImageClick(wxCommandEvent& event);
+        void OnbMultiYAxisClick(wxCommandEvent& event);
         //*)
 
         //(*Identifiers(MathPlotDemoFrame)
@@ -68,6 +69,7 @@ class MathPlotDemoFrame: public wxFrame
         wxButton* bImage;
         wxButton* bLog;
         wxButton* bLogXY;
+        wxButton* bMultiYAxis;
         wxButton* bSample;
         wxCheckBox* cbFreeLine;
         wxMenuItem* miPrint;

--- a/MathPlotDemo/wxsmith/MathPlotDemoframe.wxs
+++ b/MathPlotDemo/wxsmith/MathPlotDemoframe.wxs
@@ -68,6 +68,14 @@
 							<border>10</border>
 						</object>
 						<object class="sizeritem">
+							<object class="wxButton" name="" variable="bMultiYAxis" member="yes">
+								<label>Multi Y-Axis</label>
+								<handler function="OnbMultiYAxisClick" entry="EVT_BUTTON" />
+							</object>
+							<flag>wxBOTTOM|wxLEFT|wxRIGHT|wxEXPAND</flag>
+							<border>10</border>
+						</object>
+						<object class="sizeritem">
 							<object class="wxCheckBox" name="" variable="cbFreeLine" member="yes">
 								<label>Free line</label>
 								<tooltip>Free drawing on the plot area. Left click and move the mouse. Illustration of OnUserMouseAction</tooltip>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ I have made some improvements like :
 - added a config window (that you can have access with the right click) - makes it easy to enable/disable plots, change colors, etc.
 - add "view as bar" for XY functions
 - add horizontal and vertical line
-- add second Y axis management (only 2 Y axis supported)
+- add multiple Y axis management (unlimited number of Y-axis supported), including easy mouse interaction (zoom/pan) with each Y-axis
 - add log axis
 - view fullscreen if plot is in a single frame
 - add in the demo the samples of the original project

--- a/mathplot/mathplot.cpp
+++ b/mathplot/mathplot.cpp
@@ -141,7 +141,9 @@ void mpWindow::FillI18NString()
   // List of string message used
   MESS_HELP0 = _("wxMathPlot help");
   MESS_HELP1 = _("Supported Mouse commands:");
-  MESS_HELP2 = _(" - Left button down + Mark area: Rectangular zoom");
+  MESS_HELP2 = _(" - Left button down +\n"
+                 "    - Alt. 1: Mark area: Rectangular zoom\n"
+                 "    - Alt. 2: Move: Continous zoom");
   MESS_HELP3 = _(" - Right button down + Move: Pan (Move)");
   MESS_HELP4 = _(" - Wheel: Zoom in/out");
   MESS_HELP5 = _(" - Wheel + SHIFT: Horizontal scroll");
@@ -4512,6 +4514,26 @@ mpScaleX* mpWindow::GetLayerXAxis()
       return (mpScaleX*)(*it);
   }
   return NULL;    // Not found
+}
+
+/**
+ * Get the scale Y layer (Y axis) with a specific Y-index or NULL if not found
+ */
+mpScaleY* mpWindow::GetLayerYAxis(size_t yIndex)
+{
+  for(mpLayer* layer : m_layers)
+  {
+    int scale;
+    if (layer->IsLayerType(mpLAYER_AXIS, &scale) && (scale == mpsScaleY))
+    {
+      mpScaleY* scaleY = dynamic_cast<mpScaleY*>(layer);
+      if(scaleY->GetAxisIndex() == yIndex)
+      {
+        return scaleY;
+      }
+    }
+  }
+  return NULL;
 }
 
 std::optional<size_t> mpWindow::IsInsideYAxis(const wxPoint &point)

--- a/mathplot/mathplot.h
+++ b/mathplot/mathplot.h
@@ -2402,6 +2402,11 @@ class WXDLLIMPEXP_MATHPLOT mpWindow: public wxWindow
      */
     mpScaleX* GetLayerXAxis();
 
+    /*! Get the scale Y layer (Y axis) with a specific Y-index
+     @return A pointer to the mpScaleY object, or NULL if not found.
+     */
+    mpScaleY* GetLayerYAxis(size_t yIndex);
+
     /** Set current view's X scale and refresh display.
      @param scaleX New scale, must not be 0.
      */


### PR DESCRIPTION
By request from @DRNadler,

The demo for multiply Y-axis shows the same plots as for "Draw Sample" but with each function on separate Y-axis. All Y-axis is on the left since I think that looks best, and the colors and width of the axis has also been adjusted slightly to yield a better look for multiple Y-axis. Also a small tool tip is shown when you click the Multi Y-axis button to describe how to interact with individual Y-axis regarding zoom and panning.

Also added a GetLayerYAxis() function to mathplot in order to easier delete the Y-axis when trying a different demo plot

I tried to use wxSmith to my best ability to generate the new button and its event, but don't think I got it working properly as some unwanted code was generated: Unique wxWindowID variables were created for each button instead of using wxID_ANY, and the events were created via connect() instead of bind(). Thus I still had to manually edit some of the MathPlotDemoframe.wxs and MathPlotDemoMain.cpp. Maybe the CodeBlocks or wxSmith version I used differed somewhat from the version used to generate existing code, or there was something else I missed.. Maybe you can check if wxSmith still generate the code as expected for you @GitHubLionel?

<img width="1665" height="1043" alt="Y-axis demo" src="https://github.com/user-attachments/assets/1ea54152-2b28-473e-91fb-153e1606cebe" />
