### PR TITLE
Better calculation of Y-axis width and Y-axis mpInfoCoords

### DIFF
--- a/MathPlotConfig/MathPlotConfig.cpp
+++ b/MathPlotConfig/MathPlotConfig.cpp
@@ -802,7 +802,7 @@ void MathPlotConfigDialog::FillYAxisList(wxChoice *yChoice, bool clearChoice)
     yChoice->Clear();
   for (mpScaleY* yAxis : m_plot->GetYAxisList())
   {
-    wxString yAxisName = wxString::Format(_T("Y%d axis - %s"), (int)yAxis->GetAxisIndex()+1, yAxis->GetName());
+    wxString yAxisName = wxString::Format(_T("Y%d axis - %s"), (int)yAxis->GetAxisIndex(), yAxis->GetName());
     yChoice->Append(yAxisName, yAxis);
   }
 }

--- a/mathplot/mathplot.h
+++ b/mathplot/mathplot.h
@@ -997,10 +997,11 @@ class WXDLLIMPEXP_MATHPLOT mpInfoCoords: public mpInfoLayer
     }
 
     /** Get string describing mouse position. Override in your derived class to customize mpInfoCoords display.
+    @param w parent mpWindow from which to obtain information
     @param xVal, Value of X mouse position
     @param yValList, Values of Y. If m_series_coord is used, only one value of the closest serie is supplied,
     otherwise mouse position for each Y-axis is supplied */
-    virtual wxString GetInfoCoordsText(double xVal, std::vector<double> yValList);
+    virtual wxString GetInfoCoordsText(mpWindow &w, double xVal, std::vector<double> yValList);
 
     /** Pen series for tractable
      */
@@ -1997,6 +1998,9 @@ class WXDLLIMPEXP_MATHPLOT mpScale: public mpLayer
     virtual void SetLogAxis(bool log) = 0;
 
   protected:
+    static const wxCoord kTickSize = 4;       //!< Length of tick line
+    static const wxCoord kAxisExtraSpace = 6; //!< Extra space for axis to make it look good
+
     wxPen m_gridpen;         //!< Grid's pen. Default Colour = LIGHT_GREY, width = 1, style = wxPENSTYLE_DOT
     bool m_ticks;            //!< Flag to show ticks. Default true
     bool m_grids;            //!< Flag to show grids. Default false
@@ -2397,6 +2401,12 @@ class WXDLLIMPEXP_MATHPLOT mpWindow: public wxWindow
      * Flag for refresh legend
      */
     void RefreshLegend(void);
+
+    /*! Check if a specific Y-axis exists or is used by any function
+     @param Y-axis index to check
+     @return True if specified Y-axis is used, false otherwise
+     */
+    bool IsYAxisUsed(size_t yIndex);
 
     /*! Get the first scale X layer (X axis).
      @return A pointer to the mpScaleX object, or NULL if not found.


### PR DESCRIPTION
The Y-axis width tries to estimate the maximum size of the labels by taking the uppermost and lowermost value and checking their text size. But it did not account for that the labels are "rounded" to a specific step size, thus a lot of the time the %g format specifier added a lot of decimals which will never be shown in this specific zoom level. Fixed so that the upper and lower value is rounded properly according to the label step size. Also corrected placement of axis name to be consistant with the axis width and added constants for tick size and extra axis spacing to reduce the number of hard-coded values in the code.

Fixed so that the Y-axis mpInfoCoords only shows Y-axis values if the Y-axis exists or any function actually uses a specific Y-axis so that if you remove an Y-axis or a function it shall be reflected in the mpInfoCoords. Needed since the m_yAxisDataList that stores scales and position can never be deleted or reduced since it relys on that the index in its vector correspond to a specific Y-axis. Also added Y-axis name to the mpInfoCoords

Fixed so that Y-axis name is indexed from 0 instead of 1 in MathPlotConfig since it is indexed from 0 in mpInfoCoords and better corresponds to the actual index

In [Issue 96](https://github.com/GitHubLionel/wxMathPlot/issues/96), fixes no 1, 2 and 5 and @GitHubLionel seccond issue regarding "Y1-Y4 axis in legend"