### PR TITLE
Added FitX() and FitY() to only fit a single axis

### DIFF
--- a/mathplot/mathplot.cpp
+++ b/mathplot/mathplot.cpp
@@ -3354,6 +3354,33 @@ void mpWindow::Fit(const mpFloatRect &rect, wxCoord *printSizeX, wxCoord *printS
   }
 }
 
+void mpWindow::FitX(void)
+{
+  mpFloatRect bound = Get_Bound();
+  double Ax = bound.x.max - bound.x.min;
+  m_scaleX = ISNOTNULL(Ax) ? m_plotWidth / Ax : 1;
+
+  // Since m_posX is at the corner (not including margins) we need to take margin into account
+  m_posX = bound.x.min - (m_margin.left / m_scaleX);
+
+  UpdateDesiredBoundingBox();
+}
+
+void mpWindow::FitY(size_t yIndex)
+{
+  if(yIndex < m_yAxisDataList.size())
+  {
+    mpFloatRect bound = Get_Bound();
+    double Ay = bound.y[yIndex].max - bound.y[yIndex].min;
+    m_yAxisDataList[yIndex].m_scaleY = ISNOTNULL(Ay) ? m_plotHeight / Ay : 1;
+
+    // Since m_posY is at the corner (not including margins) we need to take margin into account
+    m_yAxisDataList[yIndex].m_posY = bound.y[yIndex].max + (m_margin.top / m_yAxisDataList[yIndex].m_scaleY);
+
+    UpdateDesiredBoundingBox();
+  }
+}
+
 void mpWindow::CheckAndReportDesiredBoundsChanges() {
   if (m_desired.IsNotSet(*this)) return; // nothing to do until useful info in m_desired
   if (!m_initialDesiredBoundsRecorded) {

--- a/mathplot/mathplot.h
+++ b/mathplot/mathplot.h
@@ -2744,6 +2744,17 @@ class WXDLLIMPEXP_MATHPLOT mpWindow: public wxWindow
      */
     void Fit(const mpFloatRect &rect, wxCoord *printSizeX = NULL, wxCoord *printSizeY = NULL);
 
+    /** Similar to Fit() but only fit in X. Intentionally don't call UpdateAll() since
+     *  you might want to perform other actions before updating plot
+     */
+    void FitX(void);
+
+    /** Similar to Fit() but only fit in Y and only one Y-axis, specified by index. Intentionally
+     *  don't call UpdateAll() since you might want to perform other actions before updating plot
+     * @param yAxis indicating which Y-axis to fit
+     */
+    void FitY(size_t yIndex);
+
     /** Zoom into current view and refresh display
      * @param centerPoint The point (pixel coordinates) that will stay in the same position on the screen after
      * the zoom (by default, the center of the mpWindow).


### PR DESCRIPTION
Useful if you only want the X or Y-axis to be fitted. Specifically useful during live plotting with auto-scrolling in X