### PR TITLE
Correction for min/max calculation in mpFXYVector

### DIFF
--- a/mathplot/mathplot.cpp
+++ b/mathplot/mathplot.cpp
@@ -1718,15 +1718,10 @@ void mpFXYVector::First_Point(double x, double y)
 
 void mpFXYVector::Check_Limit(double val, double *min, double *max, double *last, double *delta)
 {
-  if (abs(val - *last) < *delta)
-    *delta = abs(val - *last);
+  *delta = std::min(*delta, abs(val - *last));
   *last = val;
-
-  if (val < *min)
-    *min = val - *delta;
-  else
-    if (val > *max)
-      *max = val + *delta;
+  *min = std::min(*min, val);
+  *max = std::max(*max, val);
 }
 
 void mpFXYVector::SetData(const std::vector<double> &xs, const std::vector<double> &ys)
@@ -1799,7 +1794,7 @@ bool mpFXYVector::AddData(const double x, const double y, bool updatePlot)
   if (m_win)
   {
     const mpFloatRect* bbox = m_win->GetBoundingBox();
-    new_limit = (m_minX < bbox->x.min) || (m_maxX > bbox->x.max) || (m_minY < bbox->y[m_yAxisIndex].min) || (m_maxY > bbox->y[m_yAxisIndex].max);
+    new_limit = (GetMinX() < bbox->x.min) || (GetMaxX() > bbox->x.max) || (GetMinY() < bbox->y[m_yAxisIndex].min) || (GetMaxY() > bbox->y[m_yAxisIndex].max);
 
     if (updatePlot && !new_limit)
     {

--- a/mathplot/mathplot.h
+++ b/mathplot/mathplot.h
@@ -1685,7 +1685,15 @@ class WXDLLIMPEXP_MATHPLOT mpFXYVector: public mpFXY
      */
     virtual double GetMinX()
     {
-      return m_minX;
+      if(m_ViewAsBar)
+      {
+        // Make extra space for outer bars
+        return m_minX - (m_deltaX / 2);
+      }
+      else
+      {
+        return m_minX;
+      }
     }
 
     /** Returns the actual minimum Y data (loaded in SetData).
@@ -1699,7 +1707,15 @@ class WXDLLIMPEXP_MATHPLOT mpFXYVector: public mpFXY
      */
     virtual double GetMaxX()
     {
-      return m_maxX;
+      if(m_ViewAsBar)
+      {
+        // Make extra space for outer bars
+        return m_maxX + (m_deltaX / 2);
+      }
+      else
+      {
+        return m_maxX;
+      }
     }
 
     /** Returns the actual maximum Y data (loaded in SetData).
@@ -1714,7 +1730,7 @@ class WXDLLIMPEXP_MATHPLOT mpFXYVector: public mpFXY
      */
     void First_Point(double x, double y);
 
-    /** Compute the limits when we add new point
+    /** Compute the min/max values as well as the smallest distant between two neighbor points
      */
     void Check_Limit(double val, double *min, double *max, double *last, double *delta);
 


### PR DESCRIPTION
For some specific mpFXYVector series the min max calculation becomes incorrect. E.g. given a time series with increasing X-values, if the first two points in a series is much farther apart then the rest of the points, the first calculation of m_deltaX can get too large, resulting in a too large max value. And, for increasing X-values, the m_deltaX is only added to the max value and not subtracted from the min value, yielding unsymmetric boundaries. Furthermore, if bars are used, the leftmost bar (or sometimes both) will be drawn halfway outside the plot.

It seems to me that the delta is only needed for the X-axis if you plot bars, and then it's only necessary to add half of the delta to the min and max value in order to make the outermost bars visible. And only the minimum delta should be added/subtracted to the max/min value, and in order to do so consistently it need to be added after all of the points have been calculated. Fixed this by only adding it in the Getter() functions, so that the min/max variables ir "pure" min/max value and don't have to include the delta if it's not needed

**All plots below is shown after Fit() is run**

**Bars before fix. outer bars outside plot**
<img width="978" height="802" alt="Bars before" src="https://github.com/user-attachments/assets/603ecd3b-83b9-4685-b9bb-248475fae995" />

**Bars after fix. outer bars visible**
<img width="999" height="726" alt="Bars after" src="https://github.com/user-attachments/assets/a48021a9-8836-467e-8f54-8afc29e10bd7" />

**Large distance between two first points before fix. Very unsymmetric**
<img width="1065" height="454" alt="Multi extreme before" src="https://github.com/user-attachments/assets/696f638b-8870-426f-a6d1-228e5147d02a" />

**Large distance between two first points after fix. Symmetric**
<img width="889" height="460" alt="Multi extreme after" src="https://github.com/user-attachments/assets/4b28018e-7c37-4134-befb-fcadc779114e" />


