### PR TITLE
std::strtok need to include <cstring>

### DIFF
--- a/mathplot/mathplot.cpp
+++ b/mathplot/mathplot.cpp
@@ -69,6 +69,7 @@
 #include <ctime>  // used for representation of x axes involving date
 #include <fstream>
 #include <iostream> // used for std::ifstream in LoadFile() function
+#include <cstring>
 
 // If we want icon on the popup menu
 #define USE_ICON
@@ -4976,11 +4977,11 @@ bool mpWindow::LoadFile(const wxString& filename)
       continue;
 
     // Split line with separator
-    char* token = std::strtok(line.data(), seps);
+    char* token = strtok(line.data(), seps);
     while (token != nullptr)
     {
       data.push_back(atof(token));
-      token = std::strtok(nullptr, seps);
+      token = strtok(nullptr, seps);
     }
 
     // We need at least 2 data X and Y


### PR DESCRIPTION
The newly added std::strtok need "cstring". Furthermore, it is also preferable to drop the std namespace from strtok since it is a C function and not always part of std

At least I could not compile with std::strtok, but I guess it depends on compiler version. This way it should be portable for any compiler. In the end maybe strtok should be replaced by more modern c++ variant..