### PR TITLE
Add Apply and fit button in config

### DIFF
--- a/MathPlotConfig/MathPlotConfig.cpp
+++ b/MathPlotConfig/MathPlotConfig.cpp
@@ -956,6 +956,8 @@ MathPlotConfigDialog::MathPlotConfigDialog(wxWindow *parent, wxWindowID WXUNUSED
   BoxSizer2 = new wxBoxSizer(wxHORIZONTAL);
   bApply = new wxButton(this, wxID_ANY, _("Apply"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator);
   BoxSizer2->Add(bApply, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 4);
+  bApplyAndFit = new wxButton(this, wxID_ANY, _("Apply and fit"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator);
+  BoxSizer2->Add(bApplyAndFit, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
   bClose = new wxButton(this, wxID_ANY, _("Close"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator);
   BoxSizer2->Add(bClose, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 4);
   sizerMain->Add(BoxSizer2, 0, wxEXPAND, 4);
@@ -987,6 +989,7 @@ MathPlotConfigDialog::MathPlotConfigDialog(wxWindow *parent, wxWindowID WXUNUSED
   bLinesPenColor->Bind(wxEVT_COMMAND_BUTTON_CLICKED, &MathPlotConfigDialog::OnbColorClick, this);
   nbConfig->Bind(wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGED, &MathPlotConfigDialog::OnnbConfigPageChanged, this);
   bApply->Bind(wxEVT_COMMAND_BUTTON_CLICKED, &MathPlotConfigDialog::OnbApplyClick, this);
+  bApplyAndFit->Bind(wxEVT_COMMAND_BUTTON_CLICKED, &MathPlotConfigDialog::OnbApplyAndFitClick, this);
   bClose->Bind(wxEVT_COMMAND_BUTTON_CLICKED, &MathPlotConfigDialog::OnQuit, this);
   //*)
 
@@ -1472,7 +1475,7 @@ void MathPlotConfigDialog::OnbDelAxisClick(wxCommandEvent& WXUNUSED(event))
     if (wxMessageDialog(this, MESS_AXIS_DELETE, MESS_CONFIRM, wxYES_NO | wxCENTRE).ShowModal() == wxID_YES)
     {
       m_plot->DelLayer(CurrentScale, mpYesDelete, true, false); // Should we also delete the object ?
-      m_plot->Fit();
+      m_plot->UpdateAll();
       CurrentScale = NULL;
       Initialize(mpcpiAxis);
     }
@@ -1606,7 +1609,7 @@ void MathPlotConfigDialog::OnbDelSeriesClick(wxCommandEvent& WXUNUSED(event))
       m_plot->DelLayer(CurrentSerie, mpYesDelete, true, false);
       if (CurrentLegend)
         CurrentLegend->SetNeedUpdate();
-      m_plot->Fit();
+      m_plot->UpdateAll();
       CurrentSerie = NULL;
       edSeriesName->SetValue(_T(""));
       Initialize(mpcpiSeries);
@@ -1756,7 +1759,7 @@ void MathPlotConfigDialog::OnbDelLinesClick(wxCommandEvent& WXUNUSED(event))
     if (wxMessageDialog(this, MESS_LINES_DELETE, MESS_CONFIRM, wxYES_NO | wxCENTRE).ShowModal() == wxID_YES)
     {
       m_plot->DelLayer(CurrentLine, mpYesDelete, true, false);
-      m_plot->Fit();
+      m_plot->UpdateAll();
       CurrentLine = NULL;
       edLinesName->SetValue(_T(""));
       Initialize(mpcpiLines);
@@ -1767,6 +1770,12 @@ void MathPlotConfigDialog::OnbDelLinesClick(wxCommandEvent& WXUNUSED(event))
 void MathPlotConfigDialog::OnbApplyClick(wxCommandEvent& WXUNUSED(event))
 {
   Apply(nbConfig->GetSelection());
+}
+
+void MathPlotConfigDialog::OnbApplyAndFitClick(wxCommandEvent& WXUNUSED(event))
+{
+  Apply(nbConfig->GetSelection());
+  m_plot->Fit();
 }
 
 void MathPlotConfigDialog::Apply(int pageIndex, bool updateFont)
@@ -1812,7 +1821,7 @@ void MathPlotConfigDialog::Apply(int pageIndex, bool updateFont)
 
       m_plot->SetMouseLeftDownAction((mpMouseButtonAction)ChoiceLeftMouseAction->GetSelection());
 
-      m_plot->Fit();
+      m_plot->UpdateAll();
       break;
     }
     case mpcpiLegend: // Legend page
@@ -1925,7 +1934,6 @@ void MathPlotConfigDialog::Apply(int pageIndex, bool updateFont)
         else
         {
           m_plot->UpdateAll();
-          m_plot->Fit();
         }
 
         // Refresh page
@@ -1993,12 +2001,9 @@ void MathPlotConfigDialog::Apply(int pageIndex, bool updateFont)
 
         // We need to fit if we change visibility or Y axis
         if (yAxisChange || (SerieVisibleChange != cbSeriesVisible->GetValue()))
-        {
           SerieVisibleChange = cbSeriesVisible->GetValue();
-          m_plot->Fit();
-        }
-        else
-          m_plot->UpdateAll();
+
+        m_plot->UpdateAll();
       }
       break;
 

--- a/MathPlotConfig/MathPlotConfig.h
+++ b/MathPlotConfig/MathPlotConfig.h
@@ -238,6 +238,7 @@ class MathPlotConfigDialog: public wxDialog
     void OnbDelLinesClick(wxCommandEvent& event);
     void OnbDelAxisClick(wxCommandEvent& event);
     void OncbSeriesShowNameClick(wxCommandEvent& event);
+    void OnbApplyAndFitClick(wxCommandEvent& event);
     //*)
 
     //(*Identifiers(MathPlotConfigDialog)
@@ -251,6 +252,7 @@ class MathPlotConfigDialog: public wxDialog
     wxButton* bAddXAxis;
     wxButton* bAddYAxis;
     wxButton* bApply;
+    wxButton* bApplyAndFit;
     wxButton* bAxisPenColor;
     wxButton* bBGColor;
     wxButton* bClose;

--- a/MathPlotConfig/wxsmith/MathPlotConfigdialog.wxs
+++ b/MathPlotConfig/wxsmith/MathPlotConfigdialog.wxs
@@ -1609,6 +1609,15 @@
 						<option>1</option>
 					</object>
 					<object class="sizeritem">
+						<object class="wxButton" name="" variable="bApplyAndFit" member="yes">
+							<label>Apply and fit</label>
+							<handler function="OnbApplyAndFitClick" entry="EVT_BUTTON" />
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+					<object class="sizeritem">
 						<object class="wxButton" name="" variable="bClose" member="yes">
 							<label>Close</label>
 							<handler function="OnQuit" entry="EVT_BUTTON" />

--- a/mathplot/mathplot.cpp
+++ b/mathplot/mathplot.cpp
@@ -2959,6 +2959,8 @@ void mpWindow::InitParameters()
   m_InfoLegend = NULL;
   m_enableScrollBars = false;
   m_mouseLeftDownAction = mpMouseBoxZoom;
+  m_boxZoomActive = false;
+  m_autoFit = true;
 
   m_extraMargin = MP_EXTRA_MARGIN;
   // Set all margins to 50
@@ -3019,8 +3021,11 @@ void mpWindow::OnMouseLeftDown(wxMouseEvent &event)
     {
       mpScaleY* yAxis = (mpScaleY*)GetLayerYAxis(MP_OPTGET(m_mouseYAxisID));
       yAxis->SetVisible(false);
-      UpdateAll();
-      Fit();
+      if(m_autoFit)
+        Fit();
+      else
+        UpdateAll();
+
       RefreshConfigWindow(mpLAYER_AXIS);
     }
   }
@@ -3052,7 +3057,10 @@ void mpWindow::OnMouseLeftDown(wxMouseEvent &event)
         {
           CurrentSerie->SetVisible(!CurrentSerie->IsVisible());
           m_InfoLegend->SetNeedUpdate();
-          Fit();
+          if(m_autoFit)
+            Fit();
+          else
+            UpdateAll();
           RefreshConfigWindow(mpLAYER_PLOT, select);
           m_movingInfoLayer = nullptr;  // Do not allow moving
         }

--- a/mathplot/mathplot.h
+++ b/mathplot/mathplot.h
@@ -4079,6 +4079,16 @@ class WXDLLIMPEXP_MATHPLOT mpWindow: public wxWindow
      */
     static bool m_DefaultCoordIsAlwaysVisible;
 
+
+    /**
+     * Set if plot shall be auto fitted when hiding or showing axis and series via mouse
+     * @param autoFit Sets auto fit
+     */
+    void SetAutoFit(bool autoFit)
+    {
+      m_autoFit = autoFit;
+    }
+
     /** Set window margins, creating a blank area where some kinds of layers cannot draw.
      * This is useful for example to draw axes outside the area where the plots are drawn.
      @param top Top border
@@ -4584,11 +4594,12 @@ class WXDLLIMPEXP_MATHPLOT mpWindow: public wxWindow
     std::unordered_map<int, double> m_mouseScaleYList;  //!< Store current Y-scales, used as reference during drag zooming
     mpOptional_int m_mouseYAxisID;      //!< Indicate which ID of Y-axis the mouse was on during zoom/pan
     bool m_enableScrollBars;            //!< Enable scrollbar in plot window (default false)
+    bool m_autoFit;                     //!< Automatically fit plot when hiding / showing axis and series
     mpInfoLayer* m_movingInfoLayer;     //!< For moving info layers over the window area
     mpInfoCoords* m_InfoCoords;         //!< Pointer to the optional info coords layer
     mpInfoLegend* m_InfoLegend;         //!< Pointer to the optional info legend layer
 
-    bool m_boxZoomActive = false;       //!< Indicate if box zoom is active
+    bool m_boxZoomActive;               //!< Indicate if box zoom is active
 
     mpMagnet m_magnet;                  //!< For mouse magnetization
 


### PR DESCRIPTION
It is a bit annoying that the plot gets fitted everytime you click apply in config, even if you e.g. only change a text or color. To give the user a choise if he/she wants to fit or not, add a new button "Apply and fit" next to Apply, so that Apply only applies the setting (which imho is what you would expect) while "Apply and fit" also fit the plot.

Furthermore, a user might also not want to fit the plot when hiding / showing the axis or series via shift + click, so added a flag in mpWindow, m_autoFit, which can be used to set if a user wants to auto fit or not in these scenarios. Set the flag default true to keep current behavior

<img width="623" height="630" alt="Apply and fit" src="https://github.com/user-attachments/assets/9f0e5f9c-5b73-4341-b584-9b7ac7797bab" />
