### PR TITLE
Left click crash if no info legend is present

### DIFF
--- a/mathplot/mathplot.cpp
+++ b/mathplot/mathplot.cpp
@@ -956,22 +956,22 @@ void mpInfoLegend::RestoreAxisHighlighting(mpWindow &w)
   }
 }
 
-int mpInfoLegend::GetPointed(wxPoint eventPoint)
+int mpInfoLegend::GetLegendHitRegion(wxPoint mousePos)
 {
-  if(!Inside(eventPoint))
+  if(!Inside(mousePos))
     return HitNone;
 
   // First check if mouse hovers header
-  wxCoord mouseY = eventPoint.y - m_dim.y;
+  wxCoord mouseY = mousePos.y - m_dim.y;
   if (mouseY >= 0 && mouseY < m_headerEnd)
     return HitHeader;
 
   // Adjust clicked point coordinates for legend bitmap's offset within plot area
   wxCoord side;
   if (m_item_direction == mpVertical)
-    side = eventPoint.y - m_dim.y;
+    side = mousePos.y - m_dim.y;
   else
-    side = eventPoint.x - m_dim.x;
+    side = mousePos.x - m_dim.x;
 
   // Find which series legend we have clicked
   // We only need test against right or bottom side of the rectangle (stored in UpdateBitmap function).
@@ -3036,11 +3036,10 @@ void mpWindow::OnMouseLeftDown(wxMouseEvent &event)
 #endif
   }
 
-  // We are inside the Info Legend
-  if (m_InfoLegend == m_movingInfoLayer)
+  if (m_InfoLegend)
   {
-    // Get the series pointed
-    int select = m_InfoLegend->GetPointed(m_mouseLClick);
+    // Check if mouse is inside info legend and has selected a series
+    int select = m_InfoLegend->GetLegendHitRegion(m_mouseLClick);
     if (select >= 0)
     {
       // If shift is pressed, we just swap visibility of the series
@@ -3226,7 +3225,7 @@ void mpWindow::OnMouseMove(wxMouseEvent &event)
     // Mouse move on legend
     if (m_InfoLegend && m_InfoLegend->IsVisible())
     {
-      int select = m_InfoLegend->GetPointed(m_mousePos);
+      int select = m_InfoLegend->GetLegendHitRegion(m_mousePos);
       if(select == m_InfoLegend->HitHeader)
         SetCursor(wxCursor(wxCURSOR_SIZING));
       else if(select >= 0)

--- a/mathplot/mathplot.h
+++ b/mathplot/mathplot.h
@@ -1532,8 +1532,12 @@ class WXDLLIMPEXP_MATHPLOT mpInfoLegend: public mpInfoLayer
       m_needs_update = true;
     }
 
-    /// Return the index of visible layer whose legend is pointed at...
-    int GetPointed(wxPoint eventPoint);
+    /** Checks if mouse is inside legend and if it hovers the header or any of the series
+     * If a series is hovered, return its index. If the header is hovered, return HitHeader,
+     * otherwise return HitNone
+     * @param eventPoint The mouse position
+     * @return Index of series or header hit */
+    int GetLegendHitRegion(wxPoint mousePos);
 
     /** When a series is being dragged, draw a rectangle with its name at the mouse cursor.
      *  Will draw directly to dc via Blit to make it responsive, and also makes sure that
@@ -1553,7 +1557,7 @@ class WXDLLIMPEXP_MATHPLOT mpInfoLegend: public mpInfoLayer
      * @param w the window to plot */
     void RestoreAxisHighlighting(mpWindow &w);
 
-    /// Return codes for GetPointed() if no series was hit
+    /// Return codes for GetLegendHitRegion() if no series was hit
     enum HitCode : int
     {
       HitNone   = -1,


### PR DESCRIPTION
The recenttly added check "if (m_InfoLegend == m_movingInfoLayer)" does not work very well if m_InfoLegend has not been added and is = nullptr, since m_movingInfoLayer can also be nullptr and if so the equality check passes. And then it tries to call the function GetPointed from m_InfoLegend which is nullptr and crashes. Before GetPointed() is called we need to check that m_InfoLegend exists. And we don't need to check if mouse is inside the info layer since that functionality already exists in GetPointed().

However, GetPointed() is not a very good name since it now checks both if mouse is inside or not, and if it hovers the header or any series. Thus renamed it to GetLegendHitRegion() and added better description of it