### PR TITLE
Dragged series is shown unexpectedly

### DIFF
--- a/mathplot/mathplot.cpp
+++ b/mathplot/mathplot.cpp
@@ -3306,7 +3306,7 @@ void mpWindow::OnMouseLeftRelease(wxMouseEvent &event)
     }
   }
 
-  if (m_InfoLegend && m_InfoLegend->IsDraggedSeriesShown())
+  if (m_InfoLegend && m_InfoLegend->m_selectedSeries)
   {
     // Switch Y-axis of series if it was dropped on a axis
     mpOptional_int yAxisID = IsInsideYAxis(event.GetPosition());
@@ -3420,7 +3420,7 @@ void mpWindow::OnMouseLeave(wxMouseEvent &event)
   }
 
   // For InfoLegend, we need a full update
-  if (m_InfoLegend && m_InfoLegend->IsDraggedSeriesShown())
+  if (m_InfoLegend && m_InfoLegend->m_selectedSeries)
   {
     m_InfoLegend->m_selectedSeries = nullptr;
     m_InfoLegend->ShowDraggedSeries(false);


### PR DESCRIPTION
If you just click on a series (no drag) to see its config window then just after try to drag coord, it will not work correctly. Fixed by correctly deleting the dragged series when left button is released