### PR TITLE
Union mpRect has elements in wrong order

### DIFF
--- a/mathplot/mathplot.cpp
+++ b/mathplot/mathplot.cpp
@@ -1602,8 +1602,8 @@ void mpFXY::DoPlot(wxDC &dc, mpWindow &w)
   if (m_showName && !m_name.IsEmpty())
   {
     // Test if series is always visible, if no don't show name
-    if ((m_drawX.min < m_plotBoundaries.top) && (m_drawX.max > m_plotBoundaries.left) &&
-        (m_drawY.min < m_plotBoundaries.bottom) && (m_drawY.max > m_plotBoundaries.right))
+    if ((m_drawX.min < m_plotBoundaries.right) && (m_drawX.max > m_plotBoundaries.left) &&
+        (m_drawY.min < m_plotBoundaries.bottom) && (m_drawY.max > m_plotBoundaries.top))
     {
       wxCoord tx, ty, tw, th;
       dc.GetTextExtent(m_name, &tw, &th);
@@ -1639,10 +1639,10 @@ void mpFXY::DoPlot(wxDC &dc, mpWindow &w)
       if (tx < m_plotBoundaries.left)
         tx = m_plotBoundaries.left;
       else
-        if (tx + tw > m_plotBoundaries.top)
-          tx = m_plotBoundaries.top - tw;
-      if (ty < m_plotBoundaries.right)
-        ty = m_plotBoundaries.right;
+        if (tx + tw > m_plotBoundaries.right)
+          tx = m_plotBoundaries.right - tw;
+      if (ty < m_plotBoundaries.top)
+        ty = m_plotBoundaries.top;
       else
         if (ty + th > m_plotBoundaries.bottom)
           ty = m_plotBoundaries.bottom - th;

--- a/mathplot/mathplot.h
+++ b/mathplot/mathplot.h
@@ -259,8 +259,8 @@ typedef union
     struct
     {
         wxCoord startPx;
-        wxCoord endPx;
         wxCoord startPy;
+        wxCoord endPx;
         wxCoord endPy;
     };
     struct


### PR DESCRIPTION
The union mpRect holds different flavors of rectangle coordinates, and since it is a union, the elements of these "flavors" need to have correct order if you want to switch between them. However, this order is not correct. Currently it is:
* startPx = left = x1  // Ok
* endPx = top = y1  // NOK
* startPy = right = x2  // NOK
* endPy = bottom = y2 // OK 

Obviously endPx  shall not be equal to top, and startPy shall not be equal to right. Corrected by switching order of endPx and startPy.

Furthermore, this issue has been handled in the code by wrongfully checking the wrong element. I.e at one point m_drawX.min is compared to m_plotBoundaries.top. Which yields correct result only since the elements are swapped. That’s… impressively cursed.. to say the least! So corrected all instances where wrong element were used

I am, profoundly amazed, that this sneaky little bug has not caused any major issues yet..