### PR TITLE
Use binary search when iterating over mpFXYVector data points

### DIFF
--- a/mathplot/mathplot.cpp
+++ b/mathplot/mathplot.cpp
@@ -1676,14 +1676,56 @@ mpFXYVector::mpFXYVector(const wxString &name, int flags, bool viewAsBar, unsign
 
 bool mpFXYVector::GetNextXY(double *x, double *y)
 {
-  if (m_index >= m_xs.size())
+  if (m_index >= m_endIndex)
     return false;
   else
   {
     *x = m_xs[m_index];
     *y = m_ys[m_index];
-    m_index += m_step;
-    return m_index <= m_xs.size();
+    if(m_index == m_endIndex - 1)
+    {
+      // Last point has been drawn. Force exit in next call
+      m_index = m_endIndex;
+    }
+    else
+    {
+      // Make sure that last point is always drawn
+      m_index = std::min(m_index + m_step, m_endIndex - 1);
+    }
+    return true;
+  }
+}
+
+void mpFXYVector::Rewind()
+{
+  if (m_isMonotonicX)
+  {
+    // If X values are monotonic (e.g. time series), we can find the start and end X indices inside the plot
+    // boundary via binary search, which significantly increases plotting speed for large series
+    auto begin = m_xs.begin();
+    auto end   = m_xs.end();
+
+    // Find start and end indices within bound via binary search
+    mpRange<double> xRange = m_win->GetDesiredBoundX();
+    auto itStart = std::lower_bound(begin, end, xRange.min);
+    auto itEnd = std::upper_bound(begin, end, xRange.max);
+    m_index = std::distance(begin, itStart);
+    m_endIndex = std::distance(begin, itEnd);
+
+    // Increase range with one point so that first and last line also is drawn
+    if (m_index > 0)
+      m_index--;
+    if (m_endIndex < m_xs.size())
+      m_endIndex++;
+
+    // Make sure you always start on even step
+    m_index = (m_index / m_step) * m_step;
+  }
+  else
+  {
+    // If X values are not monotonic we need to iterate all data
+    m_index = 0;
+    m_endIndex = m_xs.size();
   }
 }
 
@@ -1798,22 +1840,19 @@ void mpFXYVector::SetData(const std::vector<double> &xs, const std::vector<doubl
   {
     First_Point(xs[0], ys[0]);
 
-    std::vector<double>::const_iterator it;
-
     // X scale
-    it = xs.begin();
-    it++;
-    for (; it != xs.end(); it++)
+    for (size_t i = 1; i < xs.size(); ++i)
     {
-      Check_Limit((double)(*it), &m_rangeX, &m_lastX, &m_deltaX);
+      Check_Limit(xs[i], &m_rangeX, &m_lastX, &m_deltaX);
+      // Check if all X values are monotonic, i.e. always increasing
+      if (m_isMonotonicX && (xs[i] < xs[i - 1]))
+          m_isMonotonicX = false;
     }
 
     // Y scale
-    it = ys.begin();
-    it++;
-    for (; it != ys.end(); it++)
+    for (size_t i = 1; i < ys.size(); ++i)
     {
-      Check_Limit((double)(*it), &m_rangeY, &m_lastY, &m_deltaY);
+      Check_Limit(ys[i], &m_rangeY, &m_lastY, &m_deltaY);
     }
     Rewind();
   }
@@ -1843,6 +1882,9 @@ bool mpFXYVector::AddData(const double x, const double y, bool updatePlot)
   {
     // X scale
     Check_Limit(x, &m_rangeX, &m_lastX, &m_deltaX);
+    // Check if all X values are monotonic, i.e. always increasing
+    if (m_isMonotonicX && (m_xs[m_xs.size() - 1] < m_xs[m_xs.size() - 2]))
+      m_isMonotonicX = false;
 
     // Y scale
     Check_Limit(y, &m_rangeY, &m_lastY, &m_deltaY);

--- a/mathplot/mathplot.h
+++ b/mathplot/mathplot.h
@@ -2200,31 +2200,22 @@ class WXDLLIMPEXP_MATHPLOT mpFXYVector: public mpFXY
     }
 
   protected:
-    /** The internal copy of the set of data to draw.
-     */
-    std::vector<double> m_xs;  //!< internal copy of the set of data on x direction
-    std::vector<double> m_ys;  //!< internal copy of the set of data on y direction
-
-    /** Memory reserved for m_xs and m_ys. Default 1000
-     */
-    int m_reserveXY;
-
-    /** The internal counter for the "GetNextXY" interface
-     */
-    size_t m_index;
-
+    std::vector<double> m_xs;    //!< internal copy of the set of data on x direction
+    std::vector<double> m_ys;    //!< internal copy of the set of data on y direction
+    bool m_isMonotonicX = true;  //!< Indicates if all all X values are monotonic, i.e increasing, which enables binary search
+    int m_reserveXY;             //!< Memory reserved for m_xs and m_ys. Default 1000
+    size_t m_index;              //!< The internal counter for the "GetNextXY" interface
+    size_t m_endIndex;           //!< The end index indicating the last point inside plot area
     mpRange<double> m_rangeX;    //!< Range min and max on x axis
     double m_lastX;              //!< Last x-coordinate point added
     mpRange<double> m_rangeY;    //!< Range min and max on y axis
     double m_lastY;              //!< Last y-coordinate point added
 
-    /** Rewind value enumeration with mpFXY::GetNextXY.
-     Overridden in this implementation.
+    /**
+     * Calculates the start and end index which shall be used when iterating the data. If all X values
+     * are monotonic (like a time series), the indices can be calculated using binary search
      */
-    inline void Rewind()
-    {
-      m_index = 0;
-    }
+    virtual void Rewind() override;
 
     /** Get locus value for next N.
      Overridden in this implementation.


### PR DESCRIPTION
Currently when plotting a mpFXYVector it always iterated over all data points even if you only zoom in to a small part. This makes the plot unnecessary slow for large data sets (> 100000 points). To mitigate this we can do a binary search to quickly find the X indices that is on the edge of the plot area. This significantly increases plotting speed and even a data set with > 1000000 points can be plotted quickly if you are zoomed in enough. However, binary search only works if X values are monotonic, like for a time series, so we also need to check if the X values are monotonic before appliing binary search. If it is not monotonic, fallback to the previous strategy of iterating through all data points.

Also needed to make sure that the last visible point always gets plotted even for m_step > 1.