### PR TITLE
Option to plot max number of point instead of fixed step size

### DIFF
--- a/MathPlotConfig/MathPlotConfig.cpp
+++ b/MathPlotConfig/MathPlotConfig.cpp
@@ -412,6 +412,7 @@ MathPlotConfigDialog::MathPlotConfigDialog(wxWindow *parent, wxWindowID WXUNUSED
   wxStaticBoxSizer* StaticBoxSizer10;
   wxStaticBoxSizer* StaticBoxSizer11;
   wxStaticBoxSizer* StaticBoxSizer12;
+  wxStaticBoxSizer* StaticBoxSizer13;
   wxStaticBoxSizer* StaticBoxSizer1;
   wxStaticBoxSizer* StaticBoxSizer2;
   wxStaticBoxSizer* StaticBoxSizer3;
@@ -863,17 +864,31 @@ MathPlotConfigDialog::MathPlotConfigDialog(wxWindow *parent, wxWindowID WXUNUSED
   FlexGridSizer18->Add(cbSeriesSymbolSize, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
   StaticBoxSizer10->Add(FlexGridSizer18, 0, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
   BoxSizer10->Add(StaticBoxSizer10, 0, wxALL, 2);
-  FlexGridSizer19 = new wxFlexGridSizer(1, 2, 0, 0);
-  StaticText19 = new wxStaticText(Panel4, wxID_ANY, _("Skip point over :"), wxDefaultPosition, wxDefaultSize, 0);
+  StaticBoxSizer13 = new wxStaticBoxSizer(wxHORIZONTAL, Panel4, _("Step"));
+  FlexGridSizer19 = new wxFlexGridSizer(3, 2, 0, 0);
+  StaticText19 = new wxStaticText(Panel4, wxID_ANY, _("Step size :"), wxDefaultPosition, wxDefaultSize, 0);
+  StaticText19->SetToolTip(_("Set step size, e.g. 1 to show all points, 2 to show every other step and so on"));
   FlexGridSizer19->Add(StaticText19, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
   cbSeriesStep = new wxSpinCtrl(Panel4, wxID_ANY, _T("1"), wxDefaultPosition, wxDefaultSize, 0, 1, 100, 1);
   cbSeriesStep->SetValue(_T("1"));
   FlexGridSizer19->Add(cbSeriesStep, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
-  BoxSizer10->Add(FlexGridSizer19, 0, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+  cbAutoStep = new wxCheckBox(Panel4, wxID_ANY, _("Auto step"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator);
+  cbAutoStep->SetValue(false);
+  cbAutoStep->SetToolTip(_("Automatically calculate step size based on how many points that is allowed to be shown"));
+  FlexGridSizer19->Add(cbAutoStep, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
+  FlexGridSizer19->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+  StaticText45 = new wxStaticText(Panel4, wxID_ANY, _("Max nOf points :"), wxDefaultPosition, wxDefaultSize, 0);
+  StaticText45->SetToolTip(_("Sets how many points to max show in the plot at the same time. Decrease for faster plot"));
+  FlexGridSizer19->Add(StaticText45, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+  cbMaxNOfPoints = new wxSpinCtrl(Panel4, wxID_ANY, _T("3000"), wxDefaultPosition, wxDefaultSize, 0, 1, 50000, 3000);
+  cbMaxNOfPoints->SetValue(_T("3000"));
+  FlexGridSizer19->Add(cbMaxNOfPoints, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+  StaticBoxSizer13->Add(FlexGridSizer19, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+  BoxSizer10->Add(StaticBoxSizer13, 0, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
   cbBar = new wxCheckBox(Panel4, wxID_ANY, _("View as bar"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator);
   cbBar->SetValue(false);
   cbBar->Disable();
-  BoxSizer10->Add(cbBar, 1, wxALL|wxEXPAND, 5);
+  BoxSizer10->Add(cbBar, 0, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
   FlexGridSizer15->Add(BoxSizer10, 1, wxALL|wxALIGN_TOP|wxALIGN_CENTER_HORIZONTAL, 5);
   BoxSizer8->Add(FlexGridSizer15, 0, wxALL|wxEXPAND, 2);
   Panel4->SetSizer(BoxSizer8);
@@ -983,6 +998,7 @@ MathPlotConfigDialog::MathPlotConfigDialog(wxWindow *parent, wxWindowID WXUNUSED
   bSeriesPenColor->Bind(wxEVT_COMMAND_BUTTON_CLICKED, &MathPlotConfigDialog::OnbColorClick, this);
   cbSeriesShowName->Bind(wxEVT_COMMAND_CHECKBOX_CLICKED, &MathPlotConfigDialog::OncbSeriesShowNameClick, this);
   bSeriesBrushColor->Bind(wxEVT_COMMAND_BUTTON_CLICKED, &MathPlotConfigDialog::OnbColorClick, this);
+  cbAutoStep->Bind(wxEVT_COMMAND_CHECKBOX_CLICKED, &MathPlotConfigDialog::OncbAutoStepClick, this);
   ChoiceLines->Bind(wxEVT_COMMAND_CHOICE_SELECTED, &MathPlotConfigDialog::OnChoiceLinesSelect, this);
   bAddLines->Bind(wxEVT_COMMAND_BUTTON_CLICKED, &MathPlotConfigDialog::OnbAddLinesClick, this);
   bDelLines->Bind(wxEVT_COMMAND_BUTTON_CLICKED, &MathPlotConfigDialog::OnbDelLinesClick, this);
@@ -1578,6 +1594,20 @@ void MathPlotConfigDialog::UpdateSelectedSerie(void)
   cbSeriesLegend->SetValue(CurrentSerie->GetLegendIsAlwaysVisible());
 
   cbSeriesStep->SetValue(CurrentSerie->GetStep());
+  cbAutoStep->SetValue(CurrentSerie->GetAutoStep());
+  cbMaxNOfPoints->SetValue(CurrentSerie->GetMaxNOfPoints());
+
+  if(CurrentSerie->GetAutoStep())
+  {
+    // Auto step uses max nOf points instead of fixed step
+    cbSeriesStep->Disable();
+    cbMaxNOfPoints->Enable();
+  }
+  else
+  {
+    cbSeriesStep->Enable();
+    cbMaxNOfPoints->Disable();
+  }
 
   CheckBar = (CurrentSerie->GetLayerSubType() == mpfFXYVector);
   if (CheckBar)
@@ -1616,6 +1646,26 @@ void MathPlotConfigDialog::OnbDelSeriesClick(wxCommandEvent& WXUNUSED(event))
       edSeriesName->SetValue(_T(""));
       Initialize(mpcpiSeries);
     }
+  }
+}
+
+void MathPlotConfigDialog::OncbAutoStepClick(wxCommandEvent& WXUNUSED(event))
+{
+  if(cbAutoStep->IsChecked())
+  {
+    // Auto step uses max nOf points instead of fixed step
+    cbSeriesStep->Disable();
+    cbMaxNOfPoints->Enable();
+  }
+  else
+  {
+    cbSeriesStep->Enable();
+    cbMaxNOfPoints->Disable();
+  }
+
+  if(CurrentSerie)
+  {
+    CurrentSerie->SetAutoStep(cbAutoStep->IsChecked());
   }
 }
 
@@ -1990,6 +2040,8 @@ void MathPlotConfigDialog::Apply(int pageIndex, bool updateFont)
         }
 
         CurrentSerie->SetStep(cbSeriesStep->GetValue());
+        CurrentSerie->SetAutoStep(cbAutoStep->GetValue());
+        CurrentSerie->SetMaxNOfPoints(cbMaxNOfPoints->GetValue());
 
         if (CheckBar)
         {

--- a/MathPlotConfig/MathPlotConfig.h
+++ b/MathPlotConfig/MathPlotConfig.h
@@ -239,6 +239,7 @@ class MathPlotConfigDialog: public wxDialog
     void OnbDelAxisClick(wxCommandEvent& event);
     void OncbSeriesShowNameClick(wxCommandEvent& event);
     void OnbApplyAndFitClick(wxCommandEvent& event);
+    void OncbAutoStepClick(wxCommandEvent& event);
     //*)
 
     //(*Identifiers(MathPlotConfigDialog)
@@ -269,6 +270,7 @@ class MathPlotConfigDialog: public wxDialog
     wxButton* bSeriesBrushColor;
     wxButton* bSeriesPenColor;
     wxCheckBox* cbAutoScale;
+    wxCheckBox* cbAutoStep;
     wxCheckBox* cbAxisOutside;
     wxCheckBox* cbAxisVisible;
     wxCheckBox* cbBar;
@@ -329,6 +331,7 @@ class MathPlotConfigDialog: public wxDialog
     wxPanel* Panel7;
     wxPanel* pLines;
     wxRadioButton* rbLinesDirection;
+    wxSpinCtrl* cbMaxNOfPoints;
     wxSpinCtrl* cbSeriesStep;
     wxSpinCtrl* cbSeriesSymbolSize;
     wxStaticText* StaticText10;
@@ -369,6 +372,7 @@ class MathPlotConfigDialog: public wxDialog
     wxStaticText* StaticText42;
     wxStaticText* StaticText43;
     wxStaticText* StaticText44;
+    wxStaticText* StaticText45;
     wxStaticText* StaticText4;
     wxStaticText* StaticText5;
     wxStaticText* StaticText6;

--- a/MathPlotConfig/wxsmith/MathPlotConfigdialog.wxs
+++ b/MathPlotConfig/wxsmith/MathPlotConfigdialog.wxs
@@ -1314,21 +1314,64 @@
 													<border>2</border>
 												</object>
 												<object class="sizeritem">
-													<object class="wxFlexGridSizer" variable="FlexGridSizer19" member="no">
-														<cols>2</cols>
-														<rows>1</rows>
+													<object class="wxStaticBoxSizer" variable="StaticBoxSizer13" member="no">
+														<label>Step</label>
 														<object class="sizeritem">
-															<object class="wxStaticText" name="" variable="StaticText19" member="yes">
-																<label>Skip point over :</label>
-															</object>
-															<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
-															<border>5</border>
-															<option>1</option>
-														</object>
-														<object class="sizeritem">
-															<object class="wxSpinCtrl" name="" variable="cbSeriesStep" member="yes">
-																<value>1</value>
-																<min>1</min>
+															<object class="wxFlexGridSizer" variable="FlexGridSizer19" member="no">
+																<cols>2</cols>
+																<rows>3</rows>
+																<object class="sizeritem">
+																	<object class="wxStaticText" name="" variable="StaticText19" member="yes">
+																		<label>Step size :</label>
+																		<tooltip>Set step size, e.g. 1 to show all points, 2 to show every other step and so on</tooltip>
+																	</object>
+																	<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
+																	<border>5</border>
+																	<option>1</option>
+																</object>
+																<object class="sizeritem">
+																	<object class="wxSpinCtrl" name="" variable="cbSeriesStep" member="yes">
+																		<value>1</value>
+																		<min>1</min>
+																	</object>
+																	<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+																	<border>5</border>
+																	<option>1</option>
+																</object>
+																<object class="sizeritem">
+																	<object class="wxCheckBox" name="" variable="cbAutoStep" member="yes">
+																		<label>Auto step</label>
+																		<tooltip>Automatically calculate step size based on how many points that is allowed to be shown</tooltip>
+																		<handler function="OncbAutoStepClick" entry="EVT_CHECKBOX" />
+																	</object>
+																	<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
+																	<border>5</border>
+																	<option>1</option>
+																</object>
+																<object class="spacer">
+																	<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+																	<border>5</border>
+																	<option>1</option>
+																</object>
+																<object class="sizeritem">
+																	<object class="wxStaticText" name="" variable="StaticText45" member="yes">
+																		<label>Max nOf points :</label>
+																		<tooltip>Sets how many points to max show in the plot at the same time. Decrease for faster plot</tooltip>
+																	</object>
+																	<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+																	<border>5</border>
+																	<option>1</option>
+																</object>
+																<object class="sizeritem">
+																	<object class="wxSpinCtrl" name="" variable="cbMaxNOfPoints" member="yes">
+																		<value>3000</value>
+																		<min>1</min>
+																		<max>50000</max>
+																	</object>
+																	<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+																	<border>5</border>
+																	<option>1</option>
+																</object>
 															</object>
 															<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 															<border>5</border>
@@ -1343,9 +1386,8 @@
 														<label>View as bar</label>
 														<enabled>0</enabled>
 													</object>
-													<flag>wxALL|wxEXPAND</flag>
+													<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 													<border>5</border>
-													<option>1</option>
 												</object>
 											</object>
 											<flag>wxALL|wxALIGN_TOP|wxALIGN_CENTER_HORIZONTAL</flag>

--- a/mathplot/mathplot.cpp
+++ b/mathplot/mathplot.cpp
@@ -1020,6 +1020,8 @@ mpFunction::mpFunction(mpLayerType layerType /*=mpLAYER_PLOT*/, const wxString &
   m_symbolSize2 = 3;
   m_continuous = false; // Default
   m_step = 1;
+  m_autoStep = false;
+  m_maxNOfPoints = 3000;  // 3000 points at a time can be handled without too much lag
   SetYAxisID(yAxisID);
   m_LegendIsAlwaysVisible = mpWindow::m_DefaultLegendIsAlwaysVisible;
   m_ZIndex = mpZIndex_PLOT;
@@ -1718,14 +1720,21 @@ void mpFXYVector::Rewind()
     if (m_endIndex < m_xs.size())
       m_endIndex++;
 
-    // Make sure you always start on even step
+    if(m_autoStep)
+      m_step = std::max((m_endIndex - m_index) / m_maxNOfPoints, (size_t)1);
+
+    // Make sure you always start and end on even step
     m_index = (m_index / m_step) * m_step;
+    m_endIndex = ((m_endIndex + m_step - 1) / m_step) * m_step;
+    m_endIndex = std::min(m_endIndex, m_xs.size());
   }
   else
   {
     // If X values are not monotonic we need to iterate all data
     m_index = 0;
     m_endIndex = m_xs.size();
+    if(m_autoStep)
+      m_step = std::max((m_endIndex - m_index) / m_maxNOfPoints, (size_t)1);
   }
 }
 
@@ -1798,6 +1807,9 @@ void mpFXYVector::Clear()
 {
   m_xs.clear();
   m_ys.clear();
+  // Also release allocated memory by forcing destructor
+  std::vector<double>().swap(m_xs);
+  std::vector<double>().swap(m_ys);
   // Default min max
   m_rangeX.Set(-1, 1);
   m_rangeY.Set(-1, 1);

--- a/mathplot/mathplot.h
+++ b/mathplot/mathplot.h
@@ -1743,6 +1743,36 @@ class WXDLLIMPEXP_MATHPLOT mpFunction: public mpLayer
       return m_LegendIsAlwaysVisible;
     }
 
+    /** Enables auto step which is used to plot a maximum nuber of
+     * points at a time to the plot no matter zoom level
+     * @param enable Enables auto step */
+    void SetAutoStep(bool enable)
+    {
+      m_autoStep = enable;
+    }
+
+    /** Get if auto stop is enabled
+     * @return True if auto step is enabled */
+    bool GetAutoStep() const
+    {
+      return m_autoStep;
+    }
+
+    /** Set how many points that is allowed to be drawn at a time.
+     * Reduce to speed up plotting
+     * @param nOfPoints The maximum number of points to plot */
+    void SetMaxNOfPoints(size_t nOfPoints)
+    {
+      m_maxNOfPoints = nOfPoints;
+    }
+
+    /** Get maximum number of points to plot
+     * @return Maximum number of points */
+    size_t GetMaxNOfPoints() const
+    {
+      return m_maxNOfPoints;
+    }
+
   protected:
     bool m_continuous;            //!< Specify if the layer will be plotted as a continuous line or a set of points. Default false
     mpSymbol m_symbol;            //!< A symbol for the plot in place of point. Default mpNone
@@ -1751,6 +1781,8 @@ class WXDLLIMPEXP_MATHPLOT mpFunction: public mpLayer
     unsigned int m_step;          //!< Step to get point to be draw. Default : 1
     int m_yAxisID;                //!< The ID of the Y axis used by the function. Equal 0 if no axis.
     bool m_LegendIsAlwaysVisible; //!< If true, the name is visible in the legend despite the visibility of the function. Default false
+    bool m_autoStep;              //!< Calculates m_step automatically based on how many points you want to draw
+    size_t m_maxNOfPoints;        //!< Maximum number of points to draw to screen
 
   private:
     DECLARE_DYNAMIC_CLASS_MATHPLOT(mpFunction);


### PR DESCRIPTION
Step size can be used to increase or decrease number of plotted points, but still, the more points in the series, and the more you zoom out, the more points will be plotted. For really large series this creates lag when zoomed out. Instead we intruduce an option to set the maximum allowed number of drawn points, so no matter the zoom level or number of points in the series, we never show more than a fixed number of points. This, in combination with binary search for mpFXYVector, makes it possible to plot, zoom and pan through huge series without any visible lag. When zoomed out you don't see all the point but when zoomed in more and more point becomes visible, which makes sense in a way.

To switch between using fixed step size and fixed maximum number of points, add a option "Auto step". When auto step is enabled, setting step size is greayed out (disabled) and setting max nOf points is enabled.

It is currently only implemented for mpFXYVector, but you should be able to make use of this option in other function types as well. But the largest gain is for mpFXYVector