### PR TITLE
Allow symbol size as small as 1

### DIFF
--- a/MathPlotConfig/MathPlotConfig.cpp
+++ b/MathPlotConfig/MathPlotConfig.cpp
@@ -861,7 +861,7 @@ MathPlotConfigDialog::MathPlotConfigDialog(wxWindow *parent, wxWindowID WXUNUSED
   FlexGridSizer18->Add(cbSeriesSymbolType, 1, wxALL|wxEXPAND, 2);
   StaticText10 = new wxStaticText(Panel4, wxID_ANY, _("Size :"), wxDefaultPosition, wxDefaultSize, 0);
   FlexGridSizer18->Add(StaticText10, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
-  cbSeriesSymbolSize = new wxSpinCtrl(Panel4, wxID_ANY, _T("4"), wxDefaultPosition, wxDefaultSize, 0, 4, 100, 4);
+  cbSeriesSymbolSize = new wxSpinCtrl(Panel4, wxID_ANY, _T("4"), wxDefaultPosition, wxDefaultSize, 0, 1, 100, 4);
   cbSeriesSymbolSize->SetValue(_T("4"));
   FlexGridSizer18->Add(cbSeriesSymbolSize, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
   StaticBoxSizer10->Add(FlexGridSizer18, 1, wxALL|wxEXPAND, 0);

--- a/MathPlotConfig/wxsmith/MathPlotConfigdialog.wxs
+++ b/MathPlotConfig/wxsmith/MathPlotConfigdialog.wxs
@@ -1299,7 +1299,7 @@
 																<object class="sizeritem">
 																	<object class="wxSpinCtrl" name="" variable="cbSeriesSymbolSize" member="yes">
 																		<value>4</value>
-																		<min>4</min>
+																		<min>1</min>
 																	</object>
 																	<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
 																	<border>2</border>

--- a/mathplot/mathplot.cpp
+++ b/mathplot/mathplot.cpp
@@ -1018,7 +1018,6 @@ mpFunction::mpFunction(mpLayerType layerType /*=mpLAYER_PLOT*/, const wxString &
   SetName(name);
   m_symbol = mpsNone;
   m_symbolSize = 6;
-  m_symbolSize2 = 3;
   m_continuous = false; // Default
   m_step = 1;
   m_autoStep = false;
@@ -1037,7 +1036,7 @@ bool mpFunction::DrawSymbol(wxDC &dc, wxCoord x, wxCoord y)
       break;
 
     case mpsSquare:
-      dc.DrawRectangle(x - m_symbolSize2, y - m_symbolSize2, m_symbolSize, m_symbolSize);
+      dc.DrawRectangle(x - (m_symbolSize/2), y - (m_symbolSize/2), m_symbolSize, m_symbolSize);
       break;
 
     case mpsUpTriangle:

--- a/mathplot/mathplot.h
+++ b/mathplot/mathplot.h
@@ -1705,7 +1705,6 @@ class WXDLLIMPEXP_MATHPLOT mpFunction: public mpLayer
     void SetSymbolSize(int size)
     {
       m_symbolSize = size;
-      m_symbolSize2 = size / 2;
     }
 
     /** Get symbol size.
@@ -1787,7 +1786,6 @@ class WXDLLIMPEXP_MATHPLOT mpFunction: public mpLayer
     bool m_continuous;            //!< Specify if the layer will be plotted as a continuous line or a set of points. Default false
     mpSymbol m_symbol;            //!< A symbol for the plot in place of point. Default mpNone
     int m_symbolSize;             //!< Size of the symbol. Default 6
-    int m_symbolSize2;            //!< Size of the symbol div 2.
     unsigned int m_step;          //!< Step to get point to be draw. Default : 1
     int m_yAxisID;                //!< The ID of the Y axis used by the function. Equal 0 if no axis.
     bool m_LegendIsAlwaysVisible; //!< If true, the name is visible in the legend despite the visibility of the function. Default false


### PR DESCRIPTION
For some reason symbol size can not be set lower than 4 pixels. Fixed by allowing size as small as 1 pixel, since this can be useful. Also removed member m_symbolSize2, since it is only m_symbolSize / 2 so it is redundant