### PR TITLE
Fixed minor problem with cmakelists.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ docs_output
 mathplot/mathplot.h_save.h
 mathplot/mathplot_refactorTypes.cpp
 mathplot/mathplot_refactorTypes.h
+
+# JetBrains IDE
+.idea/
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,10 @@ endif()
 # wxMathPlot lib
 set(wxmathplot_src mathplot/mathplot.cpp MathPlotConfig/MathPlotConfig.cpp)
 add_library(wxmathplot SHARED ${wxmathplot_src})
+target_link_libraries(wxmathplot PRIVATE ${wxWidgets_LIBRARIES} )
+
 add_library(wxmathplot_static ${wxmathplot_src})
+target_link_libraries(wxmathplot_static PRIVATE ${wxWidgets_LIBRARIES} )
 
 target_include_directories(wxmathplot PUBLIC
 		${CMAKE_CURRENT_SOURCE_DIR}/mathplot

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
+include (CMakePrintHelpers)
 cmake_minimum_required(VERSION 3.25)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_DEBUG_POSTFIX d)
+
 project(wxMathPlot)
 set(LIB_VERSION_MAJOR "2")
 set(LIB_VERSION_MINOR "1")
@@ -8,16 +12,33 @@ if (MSVC)
 else()
 	add_compile_options(-Wall -Wextra)
 endif()
+
 find_package(wxWidgets REQUIRED core base adv aui)
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "4.2")
+	include (UsewxWidgets)
+else()
+    include(${wxWidgets_USE_FILE})
+endif()
+
 # wxMathPlot lib
 set(wxmathplot_src mathplot/mathplot.cpp MathPlotConfig/MathPlotConfig.cpp)
 add_library(wxmathplot SHARED ${wxmathplot_src})
 add_library(wxmathplot_static ${wxmathplot_src})
-target_link_libraries(wxmathplot ${wxWidgets_LIBRARIES})
-include(${wxWidgets_USE_FILE})
-include_directories(${CMAKE_SOURCE_DIR}/MathPlotConfig)
-include_directories(${CMAKE_SOURCE_DIR}/mathplot)
-INSTALL(TARGETS wxmathplot
+
+target_include_directories(wxmathplot PUBLIC
+		${CMAKE_CURRENT_SOURCE_DIR}/mathplot
+		${CMAKE_CURRENT_SOURCE_DIR}/MathPlotConfig)
+target_include_directories(wxmathplot_static PUBLIC
+		${CMAKE_CURRENT_SOURCE_DIR}/mathplot
+		${CMAKE_CURRENT_SOURCE_DIR}/MathPlotConfig)
+
+target_link_libraries(wxmathplot INTERFACE wxmathplot ${wxWidgets_LIBRARIES})
+target_link_libraries(wxmathplot_static INTERFACE wxmathplot_static ${wxWidgets_LIBRARIES})
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/MathPlotConfig)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/mathplot)
+
+install(TARGETS wxmathplot wxmathplot_static
 	RUNTIME DESTINATION bin COMPONENT Applications
 	LIBRARY DESTINATION lib COMPONENT Libraries
 )
@@ -58,3 +79,7 @@ set(CPACK_SOURCE_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}_${LIB_VERSION_MAJOR}.$
 
 set(CPACK_COMPONENTS_ALL Libraries Development Applications)
 include(CPack)
+
+cmake_print_properties(TARGETS wxmathplot wxmathplot_static
+		PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+		           INTERFACE_LINK_LIBRARIES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,9 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "4.2")
 else()
     include(${wxWidgets_USE_FILE})
 endif()
+if (CMAKE_TOOLCHAIN_FILE)
+	find_package(WebP CONFIG REQUIRED)
+endif()
 
 # wxMathPlot lib
 set(wxmathplot_src mathplot/mathplot.cpp MathPlotConfig/MathPlotConfig.cpp)
@@ -31,9 +34,6 @@ target_include_directories(wxmathplot PUBLIC
 target_include_directories(wxmathplot_static PUBLIC
 		${CMAKE_CURRENT_SOURCE_DIR}/mathplot
 		${CMAKE_CURRENT_SOURCE_DIR}/MathPlotConfig)
-
-target_link_libraries(wxmathplot INTERFACE wxmathplot ${wxWidgets_LIBRARIES})
-target_link_libraries(wxmathplot_static INTERFACE wxmathplot_static ${wxWidgets_LIBRARIES})
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/MathPlotConfig)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/mathplot)
@@ -49,12 +49,18 @@ install(FILES MathPlotConfig/MathPlotConfig.h DESTINATION include/wxmathplot COM
 add_executable(MathPlotDemo 
 	MathPlotDemo/MathPlotDemoApp.cpp MathPlotDemo/MathPlotDemoMain.cpp
 	)
-target_link_libraries(MathPlotDemo wxmathplot_static ${wxWidgets_LIBRARIES})
+target_link_libraries(MathPlotDemo PRIVATE wxmathplot_static ${wxWidgets_LIBRARIES}  )
+if (CMAKE_TOOLCHAIN_FILE)
+	target_link_libraries(MathPlotDemo PRIVATE WebP::webp WebP::webpdecoder WebP::webpdemux )
+endif()
 
 add_executable(MathPlotConfigDemo 
 	MathPlotConfig/MathPlotConfigDemo.cpp
 	)
-target_link_libraries(MathPlotConfigDemo wxmathplot_static ${wxWidgets_LIBRARIES})
+target_link_libraries(MathPlotConfigDemo PRIVATE ${wxWidgets_LIBRARIES} wxmathplot_static )
+if (CMAKE_TOOLCHAIN_FILE)
+	target_link_libraries(MathPlotConfigDemo PRIVATE WebP::webp WebP::webpdecoder WebP::webpdemux )
+endif()
 
 if(WIN32 AND MSVC)
 	set_target_properties(MathPlotDemo PROPERTIES LINK_FLAGS "/SUBSYSTEM:WINDOWS")
@@ -79,7 +85,7 @@ set(CPACK_SOURCE_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}_${LIB_VERSION_MAJOR}.$
 
 set(CPACK_COMPONENTS_ALL Libraries Development Applications)
 include(CPack)
-
-cmake_print_properties(TARGETS wxmathplot wxmathplot_static
+cmake_print_variables(wxWidgets_LIBRARIES)
+cmake_print_properties(TARGETS wxmathplot wxmathplot_static wxWidgets::wxWidgets
 		PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
 		           INTERFACE_LINK_LIBRARIES)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "name": "wxmathplot",
+  "version": "2.1.0",
+  "dependencies": ["wxwidgets", "libwebp"]
+
+}


### PR DESCRIPTION
Closes #159.
Changed CMAKE_SOURCE_DIR to CMAKE_CURRENT_SOURCE_DIR. The first path is the directory of the top-most cmake file which is OK if building from this repository but when it is included in other project, it points on that repository directory. This gives typical error that some include files cannot be found.

Set the minimum C++ 17 level. Nothing defined seems to set C++14 level!?

Added support for VCPKG build but a WebP library problem. I suspect it's a bug with wxWidgets and VCPKG. 