### PR TITLE
Only create config window if needed

### DIFF
--- a/mathplot/mathplot.cpp
+++ b/mathplot/mathplot.cpp
@@ -3603,8 +3603,7 @@ void mpWindow::OnMouseLeftRelease(wxMouseEvent &event)
   {
     // Legend was left clicked. Open config when released
     m_openConfigWindowPending = false;
-    // Show config window
-    RefreshConfigWindow(mpLAYER_PLOT, m_infoLegendSelectedSeries, true);
+    OpenConfigWindow(mpLAYER_PLOT, m_infoLegendSelectedSeries);
   }
 
   event.Skip();
@@ -4347,7 +4346,7 @@ bool mpWindow::DelLayer(mpLayer *layer, mpDeleteAction alsoDeleteObject, bool re
 void mpWindow::DelAllLayers(mpDeleteAction alsoDeleteObject, bool refreshDisplay)
 {
   // First we delete all the function so we can after delete axis
-  DelAllPlot(alsoDeleteObject, mpfAllType, false);
+  DelAllPlot(alsoDeleteObject, mpfAllType, false, false);
 
   while (m_layers.size() > 0)
   {
@@ -4368,7 +4367,7 @@ void mpWindow::DelAllLayers(mpDeleteAction alsoDeleteObject, bool refreshDisplay
   DeleteConfigWindow();
 }
 
-void mpWindow::DelAllPlot(mpDeleteAction alsoDeleteObject, mpFunctionType func, bool refreshDisplay)
+void mpWindow::DelAllPlot(mpDeleteAction alsoDeleteObject, mpFunctionType func, bool refreshDisplay, bool refreshConfig)
 {
   int function;
   mpLayerList::iterator it = m_layers.begin();
@@ -4390,7 +4389,8 @@ void mpWindow::DelAllPlot(mpDeleteAction alsoDeleteObject, mpFunctionType func, 
   if (refreshDisplay)
     UpdateAll();
 
-  RefreshConfigWindow(mpLAYER_PLOT, -1);
+  if (refreshConfig)
+    RefreshConfigWindow(mpLAYER_PLOT, -1);
 }
 
 void mpWindow::DelAllYAxisAfterID(mpDeleteAction alsoDeleteObject, int yAxisID, bool refreshDisplay)
@@ -5525,11 +5525,13 @@ MathPlotConfigDialog* mpWindow::GetConfigWindow(bool Create)
 }
 #endif // MP_ENABLE_CONFIG
 
-void mpWindow::RefreshConfigWindow(mpLayerType layerType, int param, bool show)
+void mpWindow::RefreshConfigWindow(mpLayerType layerType, int param)
 {
 #if defined(MP_ENABLE_CONFIG) || defined(ENABLE_MP_CONFIG)
-  if (m_configWindow == NULL)
-    m_configWindow = new MathPlotConfigDialog(this);
+  if (m_configWindow == nullptr)
+    // m_configWindow is only created the first time the user opens the configuration window,
+    // thus if it has never been opened, there is no need to refresh it
+    return;
 
   switch (layerType)
   {
@@ -5548,26 +5550,25 @@ void mpWindow::RefreshConfigWindow(mpLayerType layerType, int param, bool show)
       break;
     case mpLAYER_UNDEF:
     default:
-      m_configWindow->Initialize(mpcpiGeneral);
+      m_configWindow->Initialize();   // mpcpiNone: keep the last shown page
   }
-
-  if (show)
-    m_configWindow->Show();
 #else
   (void) layerType;
   (void) param;
-  (void) show;
 #endif // MP_ENABLE_CONFIG
 }
 
-void mpWindow::OpenConfigWindow()
+void mpWindow::OpenConfigWindow(mpLayerType layerType, int param)
 {
 #if defined(MP_ENABLE_CONFIG) || defined(ENABLE_MP_CONFIG)
   if (m_configWindow == NULL)
     m_configWindow = new MathPlotConfigDialog(this);
 
-  m_configWindow->Initialize();
+  RefreshConfigWindow(layerType, param);
   m_configWindow->Show();
+#else
+  (void) layerType;
+  (void) param;
 #endif // MP_ENABLE_CONFIG
 }
 

--- a/mathplot/mathplot.h
+++ b/mathplot/mathplot.h
@@ -3465,9 +3465,10 @@ class WXDLLIMPEXP_MATHPLOT mpWindow: public wxWindow
      @param alsoDeleteObject If set to true, the mpLayer objects will be also "deleted", not just removed from the internal list.
      @param func Select type of plot
      @param refreshDisplay States whether to refresh the display (UpdateAll) after removing the layers.
+     @param refreshConfig States whether to refresh the config window (if exist)
      See DelLayer() for more infos
      */
-    void DelAllPlot(mpDeleteAction alsoDeleteObject, mpFunctionType func = mpfAllType, bool refreshDisplay = true);
+    void DelAllPlot(mpDeleteAction alsoDeleteObject, mpFunctionType func = mpfAllType, bool refreshDisplay = true, bool refreshConfig = true);
 
     /** Remove all extra y axis after the selected y axis.
      @param alsoDeleteObject If set to true, the mpLayer objects will be also "deleted", not just removed from the internal list.
@@ -4545,17 +4546,20 @@ class WXDLLIMPEXP_MATHPLOT mpWindow: public wxWindow
 #endif // MP_ENABLE_CONFIG
 
     /**
-     * Refresh the config window if present
+     * Refresh the config window if present. Never creates or shows the dialog;
+     * if no config window exists yet it simply returns.
      * @param layerType the type of layer to see the good page in the window
      * @param param specific parameter for the page
-     * @param show if true, the window is shown in any cases
      */
-    void RefreshConfigWindow(mpLayerType layerType, int param = 0, bool show = false);
+    void RefreshConfigWindow(mpLayerType layerType, int param = 0);
 
     /**
-     * Opens configuration window
+     * Opens the configuration window, creating it lazily on first use.
+     * @param layerType optional layer type to select the matching page.
+     *                  mpLAYER_UNDEF (default) keeps the last shown page.
+     * @param param specific parameter for the page (e.g. series index)
      */
-    void OpenConfigWindow();
+    void OpenConfigWindow(mpLayerType layerType = mpLAYER_UNDEF, int param = 0);
 
     /**
      * Deletes configuration window


### PR DESCRIPTION
The MathPlotConfigDialog takes ~2 s to construct, and if it has not been opened it is always created the first time RefreshConfigWindow() is called. This means that the first time you e.g. hide an axis or series the plot freeze for 2 seconds, which is a bit annoying. Instead it is now created lazily only the first time the user actually opens the configuration window, so opening the plot window and actions like hiding an axis stay instant, and sessions that never open config never pay the cost.

Also refactor the open/refresh API to remove the overloaded "show" flag to make it clear which paths actually opens the config window

- RefreshConfigWindow(layerType, param): refresh only. Never creates or shows the dialog; returns early if it doesn't exist yet. The mpLAYER_UNDEF/default case now calls Initialize() mpcpiNone) so a refresh keeps the last shown page instead of forcing the General page.
- OpenConfigWindow(layerType = mpLAYER_UNDEF, param = 0): single entry point that creates the dialog on first use, delegates page selection to RefreshConfigWindow, then Shows it. Called with no args it preserves the last shown page.
- Legend left-click now calls OpenConfigWindow(mpLAYER_PLOT, series) instead of RefreshConfigWindow(..., show=true).
- Never refresh the config window in DelAllLayers() (e.g. when destroying the mpWindow) since the config window will either way be deleted